### PR TITLE
Fix issue #20: エラー時のメッセージを具体的にする

### DIFF
--- a/api/src/routes/bookmarks.ts
+++ b/api/src/routes/bookmarks.ts
@@ -2,66 +2,66 @@ import { Hono } from "hono";
 import type { BookmarkService } from "../services/bookmark";
 
 export const createBookmarksRouter = (bookmarkService: BookmarkService) => {
-	const app = new Hono();
+        const app = new Hono();
 
-	app.get("/unread", async (c) => {
-		try {
-			const bookmarks = await bookmarkService.getUnreadBookmarks();
-			return c.json({ success: true, bookmarks });
-		} catch (error) {
-			console.error("Failed to fetch unread bookmarks:", error);
-			return c.json(
-				{ success: false, message: "Failed to fetch unread bookmarks" },
-				500,
-			);
-		}
-	});
+        app.get("/unread", async (c) => {
+                try {
+                        const bookmarks = await bookmarkService.getUnreadBookmarks();
+                        return c.json({ success: true, bookmarks });
+                } catch (error) {
+                        console.error("Failed to fetch unread bookmarks:", error);
+                        return c.json(
+                                { success: false, message: "未読ブックマークの取得に失敗しました。サーバー内部でエラーが発生しています。" },
+                                500,
+                        );
+                }
+        });
 
-	app.post("/bulk", async (c) => {
-		try {
-			const { bookmarks } = await c.req.json<{
-				bookmarks: Array<{ url: string; title: string }>;
-			}>();
+        app.post("/bulk", async (c) => {
+                try {
+                        const { bookmarks } = await c.req.json<{
+                                bookmarks: Array<{ url: string; title: string }>;
+                        }>();
 
-			// バリデーション
-			if (!Array.isArray(bookmarks)) {
-				return c.json(
-					{ success: false, message: "bookmarks must be an array" },
-					400,
-				);
-			}
+                        // バリデーション
+                        if (!Array.isArray(bookmarks)) {
+                                return c.json(
+                                        { success: false, message: "ブックマークデータは配列形式で送信してください。" },
+                                        400,
+                                );
+                        }
 
-			if (bookmarks.length === 0) {
-				return c.json(
-					{ success: false, message: "bookmarks array cannot be empty" },
-					400,
-				);
-			}
+                        if (bookmarks.length === 0) {
+                                return c.json(
+                                        { success: false, message: "ブックマークデータが空です。少なくとも1つのブックマークを含めてください。" },
+                                        400,
+                                );
+                        }
 
-			// URLの形式チェック
-			const isValidUrl = (url: string) => {
-				try {
-					new URL(url);
-					return true;
-				} catch {
-					return false;
-				}
-			};
+                        // URLの形式チェック
+                        const isValidUrl = (url: string) => {
+                                try {
+                                        new URL(url);
+                                        return true;
+                                } catch {
+                                        return false;
+                                }
+                        };
 
-			if (!bookmarks.every((b) => isValidUrl(b.url))) {
-				return c.json({ success: false, message: "invalid URL format" }, 400);
-			}
+                        if (!bookmarks.every((b) => isValidUrl(b.url))) {
+                                return c.json({ success: false, message: "URLの形式が正しくありません。有効なURLを入力してください。" }, 400);
+                        }
 
-			await bookmarkService.createBookmarksFromData(bookmarks);
-			return c.json({ success: true });
-		} catch (error) {
-			console.error("Failed to create bookmarks:", error);
-			return c.json(
-				{ success: false, message: "Failed to create bookmarks" },
-				500,
-			);
-		}
-	});
+                        await bookmarkService.createBookmarksFromData(bookmarks);
+                        return c.json({ success: true });
+                } catch (error) {
+                        console.error("Failed to create bookmarks:", error);
+                        return c.json(
+                                { success: false, message: "ブックマークの作成に失敗しました。サーバー内部でエラーが発生しています。" },
+                                500,
+                        );
+                }
+        });
 
-	return app;
+        return app;
 };

--- a/api/tests/unit/routes/bookmarks.test.ts
+++ b/api/tests/unit/routes/bookmarks.test.ts
@@ -3,162 +3,162 @@ import { createBookmarksRouter } from "../../../src/routes/bookmarks";
 import type { BookmarkService } from "../../../src/services/bookmark";
 
 describe("Bookmarks Router", () => {
-	const mockCreateBookmarksFromData = vi
-		.fn()
-		.mockImplementation(() => Promise.resolve());
-	const mockGetUnreadBookmarks = vi.fn();
+        const mockCreateBookmarksFromData = vi
+                .fn()
+                .mockImplementation(() => Promise.resolve());
+        const mockGetUnreadBookmarks = vi.fn();
 
-	const bookmarkService = {
-		createBookmarksFromData: mockCreateBookmarksFromData,
-		getUnreadBookmarks: mockGetUnreadBookmarks,
-	} satisfies BookmarkService;
+        const bookmarkService = {
+                createBookmarksFromData: mockCreateBookmarksFromData,
+                getUnreadBookmarks: mockGetUnreadBookmarks,
+        } satisfies BookmarkService;
 
-	const router = createBookmarksRouter(bookmarkService);
+        const router = createBookmarksRouter(bookmarkService);
 
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
+        beforeEach(() => {
+                vi.clearAllMocks();
+        });
 
-	describe("GET /unread", () => {
-		beforeEach(() => {
-			mockGetUnreadBookmarks.mockReset();
-		});
+        describe("GET /unread", () => {
+                beforeEach(() => {
+                        mockGetUnreadBookmarks.mockReset();
+                });
 
-		it("should return unread bookmarks successfully", async () => {
-			const now = new Date();
-			const unreadBookmarks = [
-				{
-					id: 1,
-					url: "https://example.com",
-					title: "Example",
-					isRead: false,
-					createdAt: now,
-					updatedAt: now,
-				},
-			];
-			const req = new Request("http://localhost/unread", {
-				method: "GET",
-			});
+                it("should return unread bookmarks successfully", async () => {
+                        const now = new Date();
+                        const unreadBookmarks = [
+                                {
+                                        id: 1,
+                                        url: "https://example.com",
+                                        title: "Example",
+                                        isRead: false,
+                                        createdAt: now,
+                                        updatedAt: now,
+                                },
+                        ];
+                        const req = new Request("http://localhost/unread", {
+                                method: "GET",
+                        });
 
-			mockGetUnreadBookmarks.mockResolvedValueOnce(unreadBookmarks);
+                        mockGetUnreadBookmarks.mockResolvedValueOnce(unreadBookmarks);
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(200);
-			expect(json).toEqual({
-				success: true,
-				bookmarks: unreadBookmarks.map((bookmark) => ({
-					...bookmark,
-					createdAt: bookmark.createdAt.toISOString(),
-					updatedAt: bookmark.updatedAt.toISOString(),
-				})),
-			});
-			expect(mockGetUnreadBookmarks).toHaveBeenCalledTimes(1);
-		});
+                        expect(res.status).toBe(200);
+                        expect(json).toEqual({
+                                success: true,
+                                bookmarks: unreadBookmarks.map((bookmark) => ({
+                                        ...bookmark,
+                                        createdAt: bookmark.createdAt.toISOString(),
+                                        updatedAt: bookmark.updatedAt.toISOString(),
+                                })),
+                        });
+                        expect(mockGetUnreadBookmarks).toHaveBeenCalledTimes(1);
+                });
 
-		it("should handle service errors", async () => {
-			const req = new Request("http://localhost/unread", {
-				method: "GET",
-			});
+                it("should handle service errors", async () => {
+                        const req = new Request("http://localhost/unread", {
+                                method: "GET",
+                        });
 
-			mockGetUnreadBookmarks.mockRejectedValue(new Error("Service error"));
+                        mockGetUnreadBookmarks.mockRejectedValue(new Error("Service error"));
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(500);
-			expect(json).toEqual({
-				success: false,
-				message: "Failed to fetch unread bookmarks",
-			});
-		});
-	});
+                        expect(res.status).toBe(500);
+                        expect(json).toEqual({
+                                success: false,
+                                message: "未読ブックマークの取得に失敗しました。サーバー内部でエラーが発生しています。",
+                        });
+                });
+        });
 
-	describe("POST /bulk", () => {
-		it("should create bookmarks successfully", async () => {
-			const bookmarks = [
-				{ url: "https://example.com", title: "Example" },
-				{ url: "https://example.org", title: "Example Org" },
-			];
-			const req = new Request("http://localhost/bulk", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({ bookmarks }),
-			});
+        describe("POST /bulk", () => {
+                it("should create bookmarks successfully", async () => {
+                        const bookmarks = [
+                                { url: "https://example.com", title: "Example" },
+                                { url: "https://example.org", title: "Example Org" },
+                        ];
+                        const req = new Request("http://localhost/bulk", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({ bookmarks }),
+                        });
 
-			mockCreateBookmarksFromData.mockResolvedValue(undefined);
+                        mockCreateBookmarksFromData.mockResolvedValue(undefined);
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(200);
-			expect(json).toEqual({ success: true });
-			expect(mockCreateBookmarksFromData).toHaveBeenCalledWith(bookmarks);
-		});
+                        expect(res.status).toBe(200);
+                        expect(json).toEqual({ success: true });
+                        expect(mockCreateBookmarksFromData).toHaveBeenCalledWith(bookmarks);
+                });
 
-		it("should handle invalid request body", async () => {
-			const req = new Request("http://localhost/bulk", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({ bookmarks: "not an array" }),
-			});
+                it("should handle invalid request body", async () => {
+                        const req = new Request("http://localhost/bulk", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({ bookmarks: "not an array" }),
+                        });
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(400);
-			expect(json).toEqual({
-				success: false,
-				message: "bookmarks must be an array",
-			});
-			expect(mockCreateBookmarksFromData).not.toHaveBeenCalled();
-		});
+                        expect(res.status).toBe(400);
+                        expect(json).toEqual({
+                                success: false,
+                                message: "ブックマークデータは配列形式で送信してください。",
+                        });
+                        expect(mockCreateBookmarksFromData).not.toHaveBeenCalled();
+                });
 
-		it("should handle empty bookmarks array", async () => {
-			const req = new Request("http://localhost/bulk", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({ bookmarks: [] }),
-			});
+                it("should handle empty bookmarks array", async () => {
+                        const req = new Request("http://localhost/bulk", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({ bookmarks: [] }),
+                        });
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(400);
-			expect(json).toEqual({
-				success: false,
-				message: "bookmarks array cannot be empty",
-			});
-			expect(mockCreateBookmarksFromData).not.toHaveBeenCalled();
-		});
+                        expect(res.status).toBe(400);
+                        expect(json).toEqual({
+                                success: false,
+                                message: "ブックマークデータが空です。少なくとも1つのブックマークを含めてください。",
+                        });
+                        expect(mockCreateBookmarksFromData).not.toHaveBeenCalled();
+                });
 
-		it("should handle service errors", async () => {
-			const bookmarks = [{ url: "https://example.com", title: "Example" }];
-			const req = new Request("http://localhost/bulk", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({ bookmarks }),
-			});
+                it("should handle service errors", async () => {
+                        const bookmarks = [{ url: "https://example.com", title: "Example" }];
+                        const req = new Request("http://localhost/bulk", {
+                                method: "POST",
+                                headers: {
+                                        "Content-Type": "application/json",
+                                },
+                                body: JSON.stringify({ bookmarks }),
+                        });
 
-			mockCreateBookmarksFromData.mockRejectedValue(new Error("Service error"));
+                        mockCreateBookmarksFromData.mockRejectedValue(new Error("Service error"));
 
-			const res = await router.fetch(req);
-			const json = await res.json();
+                        const res = await router.fetch(req);
+                        const json = await res.json();
 
-			expect(res.status).toBe(500);
-			expect(json).toEqual({
-				success: false,
-				message: "Failed to create bookmarks",
-			});
-		});
-	});
+                        expect(res.status).toBe(500);
+                        expect(json).toEqual({
+                                success: false,
+                                message: "ブックマークの作成に失敗しました。サーバー内部でエラーが発生しています。",
+                        });
+                });
+        });
 });

--- a/frontend/src/app/api/bookmarks/unread/route.ts
+++ b/frontend/src/app/api/bookmarks/unread/route.ts
@@ -6,34 +6,34 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-	try {
-		const response = await fetch(`${API_BASE_URL}/api/bookmarks/unread`, {
-			headers: {
-				Accept: "application/json",
-				"Content-Type": "application/json",
-			},
-			cache: "no-store",
-		});
+        try {
+                const response = await fetch(`${API_BASE_URL}/api/bookmarks/unread`, {
+                        headers: {
+                                Accept: "application/json",
+                                "Content-Type": "application/json",
+                        },
+                        cache: "no-store",
+                });
 
-		if (!response.ok) {
-			throw new Error(`HTTP error! status: ${response.status}`);
-		}
+                if (!response.ok) {
+                        throw new Error(`APIサーバーへの接続に失敗しました。ステータスコード: ${response.status}`);
+                }
 
-		const data = (await response.json()) as ApiResponse<Bookmark>;
+                const data = (await response.json()) as ApiResponse<Bookmark>;
 
-		if (!data.success) {
-			return NextResponse.json(
-				{ success: false, message: data.message || "API request failed" },
-				{ status: 400 },
-			);
-		}
+                if (!data.success) {
+                        return NextResponse.json(
+                                { success: false, message: data.message || "APIリクエストが失敗しました。" },
+                                { status: 400 },
+                        );
+                }
 
-		return NextResponse.json(data);
-	} catch (error) {
-		console.error("API error:", error);
-		return NextResponse.json(
-			{ success: false, message: "ブックマークの取得に失敗しました" },
-			{ status: 500 },
-		);
-	}
+                return NextResponse.json(data);
+        } catch (error) {
+                console.error("API error:", error);
+                return NextResponse.json(
+                        { success: false, message: "ブックマークの取得に失敗しました。サーバー内部でエラーが発生しています。" },
+                        { status: 500 },
+                );
+        }
 }

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -3,52 +3,52 @@
 import { useEffect } from "react";
 
 export default function ErrorPage({
-	error,
-	reset,
+        error,
+        reset,
 }: {
-	error: Error & { digest?: string };
-	reset: () => void;
+        error: Error & { digest?: string };
+        reset: () => void;
 }) {
-	useEffect(() => {
-		console.error("エラーが発生しました:", error);
-	}, [error]);
+        useEffect(() => {
+                console.error("エラーが発生しました:", error);
+        }, [error]);
 
-	return (
-		<main className="container mx-auto px-4 py-8">
-			<div className="bg-red-50 border-l-4 border-red-400 p-4 rounded-sm">
-				<div className="flex">
-					<div className="shrink-0">
-						<svg
-							className="h-5 w-5 text-red-400"
-							viewBox="0 0 20 20"
-							fill="currentColor"
-						>
-							<path
-								fillRule="evenodd"
-								d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-								clipRule="evenodd"
-							/>
-						</svg>
-					</div>
-					<div className="ml-3">
-						<h3 className="text-sm font-medium text-red-800">
-							エラーが発生しました
-						</h3>
-						<div className="mt-2 text-sm text-red-700">
-							<p>申し訳ありません。予期せぬエラーが発生しました。</p>
-						</div>
-						<div className="mt-4">
-							<button
-								type="button"
-								onClick={reset}
-								className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-red-700 bg-red-100 hover:bg-red-200 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-							>
-								再試行
-							</button>
-						</div>
-					</div>
-				</div>
-			</div>
-		</main>
-	);
+        return (
+                <main className="container mx-auto px-4 py-8">
+                        <div className="bg-red-50 border-l-4 border-red-400 p-4 rounded-sm">
+                                <div className="flex">
+                                        <div className="shrink-0">
+                                                <svg
+                                                        className="h-5 w-5 text-red-400"
+                                                        viewBox="0 0 20 20"
+                                                        fill="currentColor"
+                                                >
+                                                        <path
+                                                                fillRule="evenodd"
+                                                                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                                                                clipRule="evenodd"
+                                                        />
+                                                </svg>
+                                        </div>
+                                        <div className="ml-3">
+                                                <h3 className="text-sm font-medium text-red-800">
+                                                        エラーが発生しました
+                                                </h3>
+                                                <div className="mt-2 text-sm text-red-700">
+                                                        <p>申し訳ありません。予期せぬエラーが発生しました。: {error.message || "詳細不明のエラー"}</p>
+                                                </div>
+                                                <div className="mt-4">
+                                                        <button
+                                                                type="button"
+                                                                onClick={reset}
+                                                                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-red-700 bg-red-100 hover:bg-red-200 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                                                        >
+                                                                再試行
+                                                        </button>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </main>
+        );
 }

--- a/frontend/src/components/BookmarksList.tsx
+++ b/frontend/src/components/BookmarksList.tsx
@@ -7,102 +7,102 @@ import type { Bookmark } from "@/types/bookmark";
 import { useCallback, useEffect, useState } from "react";
 
 interface BookmarksListProps {
-	initialBookmarks: Bookmark[];
+        initialBookmarks: Bookmark[];
 }
 
 interface FetchError extends Error {
-	status?: number;
+        status?: number;
 }
 
 export function BookmarksList({ initialBookmarks }: BookmarksListProps) {
-	const [bookmarks, setBookmarks] = useState<Bookmark[]>(initialBookmarks);
-	const [isLoading, setIsLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
+        const [bookmarks, setBookmarks] = useState<Bookmark[]>(initialBookmarks);
+        const [isLoading, setIsLoading] = useState(false);
+        const [error, setError] = useState<string | null>(null);
 
-	const fetchBookmarks = useCallback(async () => {
-		try {
-			setIsLoading(true);
-			setError(null);
-			const response = await fetch(`${API_BASE_URL}/api/bookmarks/unread`);
-			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
-			}
-			const data: ApiBookmarkResponse = await response.json();
-			if (!data.success) {
-				const error = new Error(
-					data.message || "Failed to fetch bookmarks",
-				) as FetchError;
-				error.status = response.status;
-				throw error;
-			}
-			setBookmarks(data.bookmarks || []);
-		} catch (e) {
-			const error = e as FetchError;
-			setError(
-				`ブックマークの取得に失敗しました${error.status ? ` (${error.status})` : ""}`,
-			);
-			console.error("Error fetching bookmarks:", error);
-		} finally {
-			setIsLoading(false);
-		}
-	}, []);
+        const fetchBookmarks = useCallback(async () => {
+                try {
+                        setIsLoading(true);
+                        setError(null);
+                        const response = await fetch(`${API_BASE_URL}/api/bookmarks/unread`);
+                        if (!response.ok) {
+                                throw new Error(`サーバーエラーが発生しました。ステータスコード: ${response.status}`);
+                        }
+                        const data: ApiBookmarkResponse = await response.json();
+                        if (!data.success) {
+                                const error = new Error(
+                                        data.message || "ブックマークの取得に失敗しました。",
+                                ) as FetchError;
+                                error.status = response.status;
+                                throw error;
+                        }
+                        setBookmarks(data.bookmarks || []);
+                } catch (e) {
+                        const error = e as FetchError;
+                        setError(
+                                `ブックマークの取得に失敗しました。${error.message || ""}${error.status ? ` (ステータスコード: ${error.status})` : ""}`,
+                        );
+                        console.error("Error fetching bookmarks:", error);
+                } finally {
+                        setIsLoading(false);
+                }
+        }, []);
 
-	useEffect(() => {
-		fetchBookmarks();
-	}, [fetchBookmarks]);
+        useEffect(() => {
+                fetchBookmarks();
+        }, [fetchBookmarks]);
 
-	return (
-		<div>
-			<div className="flex justify-between items-center mb-6">
-				<h1 className="text-2xl font-bold">未読ブックマーク</h1>
-				<button
-					type="button"
-					onClick={fetchBookmarks}
-					className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-					disabled={isLoading}
-				>
-					{isLoading ? (
-						<div className="flex items-center">
-							<div className="animate-spin h-4 w-4 mr-2 border-2 border-white border-t-transparent rounded-full" />
-							更新中...
-						</div>
-					) : (
-						<>
-							<svg
-								className="mr-2 h-4 w-4"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									strokeWidth={2}
-									d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-								/>
-							</svg>
-							更新
-						</>
-					)}
-				</button>
-			</div>
+        return (
+                <div>
+                        <div className="flex justify-between items-center mb-6">
+                                <h1 className="text-2xl font-bold">未読ブックマーク</h1>
+                                <button
+                                        type="button"
+                                        onClick={fetchBookmarks}
+                                        className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                                        disabled={isLoading}
+                                >
+                                        {isLoading ? (
+                                                <div className="flex items-center">
+                                                        <div className="animate-spin h-4 w-4 mr-2 border-2 border-white border-t-transparent rounded-full" />
+                                                        更新中...
+                                                </div>
+                                        ) : (
+                                                <>
+                                                        <svg
+                                                                className="mr-2 h-4 w-4"
+                                                                fill="none"
+                                                                stroke="currentColor"
+                                                                viewBox="0 0 24 24"
+                                                                xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                                <path
+                                                                        strokeLinecap="round"
+                                                                        strokeLinejoin="round"
+                                                                        strokeWidth={2}
+                                                                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                                                                />
+                                                        </svg>
+                                                        更新
+                                                </>
+                                        )}
+                                </button>
+                        </div>
 
-			{error && (
-				<div className="bg-red-50 border-l-4 border-red-400 p-4 rounded-sm mb-6">
-					<p className="text-red-700">{error}</p>
-				</div>
-			)}
+                        {error && (
+                                <div className="bg-red-50 border-l-4 border-red-400 p-4 rounded-sm mb-6">
+                                        <p className="text-red-700">{error}</p>
+                                </div>
+                        )}
 
-			{bookmarks.length === 0 ? (
-				<p className="text-gray-600">未読のブックマークはありません。</p>
-			) : (
-				<div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-					{bookmarks.map((bookmark) => (
-						<BookmarkCard key={bookmark.id} bookmark={bookmark} />
-					))}
-				</div>
-			)}
-		</div>
-	);
+                        {bookmarks.length === 0 ? (
+                                <p className="text-gray-600">未読のブックマークはありません。</p>
+                        ) : (
+                                <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+                                        {bookmarks.map((bookmark) => (
+                                                <BookmarkCard key={bookmark.id} bookmark={bookmark} />
+                                        ))}
+                                </div>
+                        )}
+                </div>
+        );
 }

--- a/frontend/src/components/__tests__/BookmarksList.test.tsx
+++ b/frontend/src/components/__tests__/BookmarksList.test.tsx
@@ -6,98 +6,98 @@ import { BookmarksList } from "../BookmarksList";
 
 // モック用のレスポンス型
 type MockResponse = Response & {
-	json: () => Promise<ApiBookmarkResponse>;
+        json: () => Promise<ApiBookmarkResponse>;
 };
 
 // APIレスポンスのモック
 const mockBookmarks: Bookmark[] = [
-	{
-		id: 1,
-		url: "https://example.com",
-		title: "Example Title",
-		isRead: false,
-		createdAt: "2024-03-01T00:00:00.000Z",
-		updatedAt: "2024-03-01T00:00:00.000Z",
-	},
+        {
+                id: 1,
+                url: "https://example.com",
+                title: "Example Title",
+                isRead: false,
+                createdAt: "2024-03-01T00:00:00.000Z",
+                updatedAt: "2024-03-01T00:00:00.000Z",
+        },
 ];
 
 describe("BookmarksList", () => {
-	beforeEach(() => {
-		// fetchのモックをリセット
-		vi.restoreAllMocks();
-		// コンソールエラーを抑制
-		vi.spyOn(console, "error").mockImplementation(() => {});
-	});
+        beforeEach(() => {
+                // fetchのモックをリセット
+                vi.restoreAllMocks();
+                // コンソールエラーを抑制
+                vi.spyOn(console, "error").mockImplementation(() => {});
+        });
 
-	afterEach(() => {
-		// コンソールエラーの抑制を解除
-		vi.restoreAllMocks();
-	});
+        afterEach(() => {
+                // コンソールエラーの抑制を解除
+                vi.restoreAllMocks();
+        });
 
-	it("初期状態で空の配列を表示する", () => {
-		render(<BookmarksList initialBookmarks={[]} />);
-		expect(screen.getByText("未読のブックマークはありません。")).toBeDefined();
-	});
+        it("初期状態で空の配列を表示する", () => {
+                render(<BookmarksList initialBookmarks={[]} />);
+                expect(screen.getByText("未読のブックマークはありません。")).toBeDefined();
+        });
 
-	it("ローディング中は更新ボタンが無効になる", async () => {
-		// fetchのモックを設定
-		global.fetch = vi.fn().mockImplementation(
-			() =>
-				new Promise<MockResponse>((resolve) =>
-					setTimeout(
-						() =>
-							resolve({
-								ok: true,
-								json: async () => ({ success: true, bookmarks: [] }),
-							} as MockResponse),
-						100,
-					),
-				),
-		);
+        it("ローディング中は更新ボタンが無効になる", async () => {
+                // fetchのモックを設定
+                global.fetch = vi.fn().mockImplementation(
+                        () =>
+                                new Promise<MockResponse>((resolve) =>
+                                        setTimeout(
+                                                () =>
+                                                        resolve({
+                                                                ok: true,
+                                                                json: async () => ({ success: true, bookmarks: [] }),
+                                                        } as MockResponse),
+                                                100,
+                                        ),
+                                ),
+                );
 
-		render(<BookmarksList initialBookmarks={[]} />);
+                render(<BookmarksList initialBookmarks={[]} />);
 
-		const updateButton = screen.getByRole("button");
-		await act(async () => {
-			fireEvent.click(updateButton);
-		});
+                const updateButton = screen.getByRole("button");
+                await act(async () => {
+                        fireEvent.click(updateButton);
+                });
 
-		expect(updateButton).toHaveProperty("disabled", true);
-		expect(screen.getByText("更新中...")).toBeDefined();
-	});
+                expect(updateButton).toHaveProperty("disabled", true);
+                expect(screen.getByText("更新中...")).toBeDefined();
+        });
 
-	it("エラー時にエラーメッセージを表示する", async () => {
-		// fetchのモックを設定（エラーを返す）
-		global.fetch = vi.fn().mockRejectedValue(new Error("API Error"));
+        it("エラー時にエラーメッセージを表示する", async () => {
+                // fetchのモックを設定（エラーを返す）
+                global.fetch = vi.fn().mockRejectedValue(new Error("API Error"));
 
-		render(<BookmarksList initialBookmarks={[]} />);
+                render(<BookmarksList initialBookmarks={[]} />);
 
-		await act(async () => {
-			// 非同期処理の完了を待つ
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		});
+                await act(async () => {
+                        // 非同期処理の完了を待つ
+                        await new Promise((resolve) => setTimeout(resolve, 0));
+                });
 
-		expect(screen.getByText("ブックマークの取得に失敗しました")).toBeDefined();
-	});
+                expect(screen.getByText(/ブックマークの取得に失敗しました/)).toBeDefined();
+        });
 
-	it("データ取得後にブックマークを表示する", async () => {
-		// fetchのモックを設定（成功レスポンスを返す）
-		global.fetch = vi.fn().mockResolvedValue({
-			ok: true,
-			json: () =>
-				Promise.resolve({
-					success: true,
-					bookmarks: mockBookmarks,
-				}),
-		} as MockResponse);
+        it("データ取得後にブックマークを表示する", async () => {
+                // fetchのモックを設定（成功レスポンスを返す）
+                global.fetch = vi.fn().mockResolvedValue({
+                        ok: true,
+                        json: () =>
+                                Promise.resolve({
+                                        success: true,
+                                        bookmarks: mockBookmarks,
+                                }),
+                } as MockResponse);
 
-		render(<BookmarksList initialBookmarks={[]} />);
+                render(<BookmarksList initialBookmarks={[]} />);
 
-		await act(async () => {
-			// 非同期処理の完了を待つ
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		});
+                await act(async () => {
+                        // 非同期処理の完了を待つ
+                        await new Promise((resolve) => setTimeout(resolve, 0));
+                });
 
-		expect(screen.getByText("Example Title")).toBeDefined();
-	});
+                expect(screen.getByText("Example Title")).toBeDefined();
+        });
 });

--- a/frontend/src/lib/api/bookmarks.ts
+++ b/frontend/src/lib/api/bookmarks.ts
@@ -3,54 +3,54 @@ import type { Bookmark } from "@/types/bookmark";
 import { API_BASE_URL } from "./config";
 
 interface ApiError extends Error {
-	status?: number;
+        status?: number;
 }
 
 function getApiUrl() {
-	if (typeof window === "undefined") {
-		// サーバーサイド
-		return `${API_BASE_URL}/api/bookmarks/unread`;
-	}
-	// クライアントサイド
-	return `${window.location.origin}/api/bookmarks/unread`;
+        if (typeof window === "undefined") {
+                // サーバーサイド
+                return `${API_BASE_URL}/api/bookmarks/unread`;
+        }
+        // クライアントサイド
+        return `${window.location.origin}/api/bookmarks/unread`;
 }
 
 export async function getUnreadBookmarks(): Promise<Bookmark[]> {
-	try {
-		const response = await fetch(getApiUrl(), {
-			headers: {
-				Accept: "application/json",
-				"Content-Type": "application/json",
-			},
-			cache: "no-store",
-			next: { revalidate: 0 },
-		});
-		if (!response.ok) {
-			throw new Error(`HTTP error! status: ${response.status}`);
-		}
-		const text = await response.text();
-		try {
-			const data: ApiBookmarkResponse = JSON.parse(text);
-			console.log("API Response:", { status: response.status, data });
-			if (!data.success) {
-				const error = new Error(
-					data.message || "未読ブックマークの取得に失敗しました",
-				);
-				Object.assign(error, { status: response.status });
-				throw error;
-			}
-			return data.bookmarks || [];
-		} catch (e) {
-			if (e instanceof SyntaxError) {
-				console.error("JSON parse error:", e);
-				console.error("Response text:", text);
-				console.error("Response status:", response.status);
-				throw new Error("レスポンスの解析に失敗しました");
-			}
-			throw e;
-		}
-	} catch (error) {
-		console.error("API error:", error);
-		throw error;
-	}
+        try {
+                const response = await fetch(getApiUrl(), {
+                        headers: {
+                                Accept: "application/json",
+                                "Content-Type": "application/json",
+                        },
+                        cache: "no-store",
+                        next: { revalidate: 0 },
+                });
+                if (!response.ok) {
+                        throw new Error(`APIサーバーへの接続に失敗しました。ステータスコード: ${response.status}`);
+                }
+                const text = await response.text();
+                try {
+                        const data: ApiBookmarkResponse = JSON.parse(text);
+                        console.log("API Response:", { status: response.status, data });
+                        if (!data.success) {
+                                const error = new Error(
+                                        data.message || "未読ブックマークの取得に失敗しました",
+                                );
+                                Object.assign(error, { status: response.status });
+                                throw error;
+                        }
+                        return data.bookmarks || [];
+                } catch (e) {
+                        if (e instanceof SyntaxError) {
+                                console.error("JSON parse error:", e);
+                                console.error("Response text:", text);
+                                console.error("Response status:", response.status);
+                                throw new Error("APIレスポンスの解析に失敗しました。不正なJSONフォーマットが返されました。");
+                        }
+                        throw e;
+                }
+        } catch (error) {
+                console.error("API error:", error);
+                throw error;
+        }
 }


### PR DESCRIPTION
This pull request fixes #20.

The issue has been successfully resolved. The PR has updated all error messages throughout the application to be displayed in Japanese with more descriptive content. Specifically:

1. In the API routes (backend):
   - Changed generic error messages like "Failed to fetch unread bookmarks" to Japanese equivalents like "未読ブックマークの取得に失敗しました。サーバー内部でエラーが発生しています。"
   - Improved validation error messages with more specific Japanese text explaining what went wrong
   - Added more context to server errors to help users understand the issue

2. In the frontend components:
   - Updated error handling to display more detailed Japanese error messages
   - Enhanced error displays to include error codes and more specific information
   - Modified the error page to show the actual error message for better debugging

3. In the tests:
   - Updated test expectations to match the new Japanese error messages

The changes are comprehensive, covering both the API and frontend components, and all tests are now passing. This implementation satisfies the requirement to display error messages in Japanese throughout the application, making the user experience more intuitive for Japanese users.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌