### PR TITLE
🐛 fix: デプロイエラーを修正するためKVキャッシュ設定を自動化

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
 		"lint": "npx @biomejs/biome check",
 		"format": "npx @biomejs/biome check --write",
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"deploy:setup": "bash ./setup-deploy.sh",
+		"deploy": "bun run deploy:setup && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
 		"knip": "knip"
 	},

--- a/frontend/setup-deploy.sh
+++ b/frontend/setup-deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Check if required environment variables are set
+if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+  echo "CLOUDFLARE_API_TOKEN is not set"
+  exit 1
+fi
+
+if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+  echo "CLOUDFLARE_ACCOUNT_ID is not set"
+  exit 1
+fi
+
+# Create KV namespace if it doesn't exist
+echo "Creating KV namespace for Next.js incremental cache..."
+KV_NAMESPACE_NAME="effective-yomimono-next-cache"
+
+# Check if namespace already exists
+EXISTING_NAMESPACE=$(wrangler kv:namespace list --compatibility-date=2024-09-26 | grep "\"$KV_NAMESPACE_NAME\"" | awk '{print $2}' | tr -d '"')
+
+if [ -z "$EXISTING_NAMESPACE" ]; then
+  # Create new namespace
+  echo "Creating new KV namespace: $KV_NAMESPACE_NAME"
+  KV_NAMESPACE_ID=$(wrangler kv:namespace create "$KV_NAMESPACE_NAME" --compatibility-date=2024-09-26 --preview false | grep "id =" | awk '{print $3}' | tr -d '"')
+else
+  # Use existing namespace
+  echo "Using existing KV namespace: $EXISTING_NAMESPACE"
+  KV_NAMESPACE_ID=$EXISTING_NAMESPACE
+fi
+
+if [ -z "$KV_NAMESPACE_ID" ]; then
+  echo "Failed to get KV namespace ID"
+  exit 1
+fi
+
+echo "KV namespace ID: $KV_NAMESPACE_ID"
+
+# Update wrangler.jsonc with the actual KV namespace ID
+sed -i.bak "s/PLACEHOLDER_KV_NAMESPACE_ID/$KV_NAMESPACE_ID/g" wrangler.jsonc
+
+# Remove backup file
+rm -f wrangler.jsonc.bak
+
+echo "Updated wrangler.jsonc with KV namespace ID"

--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -15,7 +15,13 @@
 	},
 	"observability": {
 		"enabled": true
-	}
+	},
+	"kv_namespaces": [
+		{
+			"binding": "NEXT_INC_CACHE_KV",
+			"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+		}
+	]
 	/**
 	 * Smart Placement
 	 * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement


### PR DESCRIPTION
## Summary
- OpenNext CloudflareのKVインクリメンタルキャッシュが設定されていないためのデプロイエラーを修正
- KV namespaceを自動的に作成・設定するデプロイスクリプトを追加
- CI/CDパイプラインでのデプロイプロセスを改善

## Changes
1. `frontend/wrangler.jsonc`にKVバインディング設定を追加
2. `frontend/setup-deploy.sh`を作成して、デプロイ時に自動的にKV namespaceを作成
3. `frontend/package.json`のデプロイスクリプトを更新して、設定スクリプトを実行

## Test plan
- [x] ローカルでリントとフォーマットチェックが通ることを確認
- [ ] CI/CDパイプラインでデプロイが成功することを確認
- [ ] KV namespaceが正しく作成されることを確認

## Related Issues
closes #379

🤖 Generated with [Claude Code](https://claude.ai/code)