### PR TITLE
✨ feat: リンククリック時に既読にする機能を追加

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -34,6 +34,14 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		markAsReadMutate(id);
 	};
 
+	// リンククリック時に既読にする処理を追加
+	const handleLinkClick = () => {
+		if (!isRead) {
+			// 非同期で既読にする（結果を待たない）
+			markAsReadMutate(id);
+		}
+	};
+
 	return (
 		<article
 			className={`relative p-4 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
@@ -166,6 +174,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					target="_blank"
 					rel="noopener noreferrer"
 					className="hover:text-blue-600"
+					onClick={handleLinkClick}
 				>
 					{title || "タイトルなし"}
 				</a>


### PR DESCRIPTION
## 概要
- ブックマークのリンクをクリックした際に自動的に既読にする機能を実装

## 変更内容
- `BookmarkCard`コンポーネントに`handleLinkClick`関数を追加
- リンクの`onClick`ハンドラーにこの関数を設定
- 既読でない場合のみ非同期で既読APIを呼び出すように実装

## テスト方法
- [ ] ブックマークカードのタイトルリンクをクリック
- [ ] 既読状態になることを確認
- [ ] 既読のブックマークをクリックしても再度APIが呼ばれないことを確認

Closes #369

🤖 Generated with [Claude Code](https://claude.ai/code)