### PR TITLE
🐛 fix: KV namespace IDのJSONパースを修正

### DIFF
--- a/frontend/setup-deploy.sh
+++ b/frontend/setup-deploy.sh
@@ -32,7 +32,8 @@ else
   echo "List output: $LIST_OUTPUT"
   
   # Parse JSON output to find our namespace ID
-  KV_NAMESPACE_ID=$(echo "$LIST_OUTPUT" | grep -A2 "\"title\": \"$KV_NAMESPACE_NAME\"" | grep '"id"' | sed 's/.*"id": "\([^"]*\)".*/\1/')
+  # Look for the ID that appears right before our namespace title
+  KV_NAMESPACE_ID=$(echo "$LIST_OUTPUT" | grep -B1 "\"title\": \"$KV_NAMESPACE_NAME\"" | head -1 | sed -n 's/.*"id": "\([^"]*\)".*/\1/p')
   
   if [ -z "$KV_NAMESPACE_ID" ]; then
     echo "Failed to find namespace ID in list output"


### PR DESCRIPTION
## Summary
- wrangler kv namespace listの出力からIDを正しく抽出するようにパースロジックを修正

## Problem
既存のKV namespaceのIDを取得する際、JSONパースが正しく動作していなかった

## Solution
- grep -B1を使用して、titleの前の行からIDを抽出
- sedパターンを調整してより確実にIDを抽出

## Test plan
- [ ] CI/CDパイプラインでKV namespaceのIDが正しく検出されることを確認
- [ ] デプロイが成功することを確認

## Related Issues
- Continues from #392, #390, #389, and #379

🤖 Generated with [Claude Code](https://claude.ai/code)