### PR TITLE
🧺 chore: デプロイスクリプトからデバッグ用のecho文を削除

### DIFF
--- a/frontend/setup-deploy.sh
+++ b/frontend/setup-deploy.sh
@@ -16,9 +16,7 @@ echo "Creating KV namespace for Next.js incremental cache..."
 KV_NAMESPACE_NAME="effective-yomimono-next-cache"
 
 # Try to create namespace (it will fail if it already exists)
-echo "Attempting to create KV namespace: $KV_NAMESPACE_NAME"
 CREATE_OUTPUT=$(wrangler kv namespace create "$KV_NAMESPACE_NAME" 2>&1 || true)
-echo "Create output: $CREATE_OUTPUT"
 
 # Extract ID from creation output or list existing namespaces
 if echo "$CREATE_OUTPUT" | grep -q "id = "; then
@@ -27,9 +25,7 @@ if echo "$CREATE_OUTPUT" | grep -q "id = "; then
   echo "Created new KV namespace with ID: $KV_NAMESPACE_ID"
 else
   # Namespace might already exist, list all namespaces
-  echo "Namespace might already exist, listing all namespaces..."
   LIST_OUTPUT=$(wrangler kv namespace list 2>&1)
-  echo "List output: $LIST_OUTPUT"
   
   # Parse JSON output to find our namespace ID
   # Look for the ID that appears right before our namespace title


### PR DESCRIPTION
## Summary
デプロイスクリプトから不要になったデバッグ用のecho文を削除します。

## Changes
- \から以下のデバッグ出力を削除：
  - \"Create output: $CREATE_OUTPUT"
  - \"List output: $LIST_OUTPUT"
  - \"Attempting to create KV namespace: $KV_NAMESPACE_NAME"
  - \"Namespace might already exist, listing all namespaces..."

## Rationale
- これらのecho文はIssue #379のデバッグのために追加されたもの
- CIが正常に動作するようになったため、不要になった
- ログの簡潔性を保つために削除

## Test plan
- [ ] CIが変わらず正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)