### PR TITLE
✨ feat: 記事要約機能 Phase 2 コア機能実装

### DIFF
--- a/api/drizzle/0004_old_eternity.sql
+++ b/api/drizzle/0004_old_eternity.sql
@@ -1,0 +1,50 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_article_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`article_id` integer NOT NULL,
+	`label_id` integer NOT NULL,
+	`created_at` integer DEFAULT '"2025-05-17T14:37:36.202Z"' NOT NULL,
+	FOREIGN KEY (`article_id`) REFERENCES `bookmarks`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`label_id`) REFERENCES `labels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_article_labels`("id", "article_id", "label_id", "created_at") SELECT "id", "article_id", "label_id", "created_at" FROM `article_labels`;--> statement-breakpoint
+DROP TABLE `article_labels`;--> statement-breakpoint
+ALTER TABLE `__new_article_labels` RENAME TO `article_labels`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_bookmarks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`url` text NOT NULL,
+	`title` text,
+	`is_read` integer DEFAULT false NOT NULL,
+	`summary` text,
+	`created_at` integer DEFAULT '"2025-05-17T14:37:36.201Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-05-17T14:37:36.201Z"' NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_bookmarks`("id", "url", "title", "is_read", "summary", "created_at", "updated_at") SELECT "id", "url", "title", "is_read", "summary", "created_at", "updated_at" FROM `bookmarks`;--> statement-breakpoint
+DROP TABLE `bookmarks`;--> statement-breakpoint
+ALTER TABLE `__new_bookmarks` RENAME TO `bookmarks`;--> statement-breakpoint
+CREATE TABLE `__new_favorites` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`bookmark_id` integer NOT NULL,
+	`created_at` integer DEFAULT '"2025-05-17T14:37:36.201Z"' NOT NULL,
+	FOREIGN KEY (`bookmark_id`) REFERENCES `bookmarks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_favorites`("id", "bookmark_id", "created_at") SELECT "id", "bookmark_id", "created_at" FROM `favorites`;--> statement-breakpoint
+DROP TABLE `favorites`;--> statement-breakpoint
+ALTER TABLE `__new_favorites` RENAME TO `favorites`;--> statement-breakpoint
+CREATE UNIQUE INDEX `favorites_bookmark_id_unique` ON `favorites` (`bookmark_id`);--> statement-breakpoint
+CREATE TABLE `__new_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`created_at` integer DEFAULT '"2025-05-17T14:37:36.201Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-05-17T14:37:36.201Z"' NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_labels`("id", "name", "description", "created_at", "updated_at") SELECT "id", "name", "description", "created_at", "updated_at" FROM `labels`;--> statement-breakpoint
+DROP TABLE `labels`;--> statement-breakpoint
+ALTER TABLE `__new_labels` RENAME TO `labels`;--> statement-breakpoint
+CREATE UNIQUE INDEX `labels_name_unique` ON `labels` (`name`);

--- a/api/drizzle/meta/0003_snapshot.json
+++ b/api/drizzle/meta/0003_snapshot.json
@@ -1,8 +1,6 @@
 {
-	"version": "5",
+	"version": "6",
 	"dialect": "sqlite",
-	"id": "af02f2d3-1889-4bf5-ba40-d0f99d33e28c",
-	"prevId": "2c3bca22-4be0-4516-bded-7c4f6151a6fc",
 	"tables": {
 		"article_labels": {
 			"name": "article_labels",
@@ -42,24 +40,25 @@
 				"article_labels_article_id_bookmarks_id_fk": {
 					"name": "article_labels_article_id_bookmarks_id_fk",
 					"tableFrom": "article_labels",
-					"tableTo": "bookmarks",
 					"columnsFrom": ["article_id"],
+					"tableTo": "bookmarks",
 					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
+					"onUpdate": "no action",
+					"onDelete": "cascade"
 				},
 				"article_labels_label_id_labels_id_fk": {
 					"name": "article_labels_label_id_labels_id_fk",
 					"tableFrom": "article_labels",
-					"tableTo": "labels",
 					"columnsFrom": ["label_id"],
+					"tableTo": "labels",
 					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
+					"onUpdate": "no action",
+					"onDelete": "cascade"
 				}
 			},
 			"compositePrimaryKeys": {},
-			"uniqueConstraints": {}
+			"uniqueConstraints": {},
+			"checkConstraints": {}
 		},
 		"bookmarks": {
 			"name": "bookmarks",
@@ -113,7 +112,8 @@
 			"indexes": {},
 			"foreignKeys": {},
 			"compositePrimaryKeys": {},
-			"uniqueConstraints": {}
+			"uniqueConstraints": {},
+			"checkConstraints": {}
 		},
 		"favorites": {
 			"name": "favorites",
@@ -152,15 +152,16 @@
 				"favorites_bookmark_id_bookmarks_id_fk": {
 					"name": "favorites_bookmark_id_bookmarks_id_fk",
 					"tableFrom": "favorites",
-					"tableTo": "bookmarks",
 					"columnsFrom": ["bookmark_id"],
+					"tableTo": "bookmarks",
 					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
+					"onUpdate": "no action",
+					"onDelete": "cascade"
 				}
 			},
 			"compositePrimaryKeys": {},
-			"uniqueConstraints": {}
+			"uniqueConstraints": {},
+			"checkConstraints": {}
 		},
 		"labels": {
 			"name": "labels",
@@ -212,13 +213,16 @@
 			},
 			"foreignKeys": {},
 			"compositePrimaryKeys": {},
-			"uniqueConstraints": {}
+			"uniqueConstraints": {},
+			"checkConstraints": {}
 		}
 	},
 	"enums": {},
 	"_meta": {
-		"schemas": {},
 		"tables": {},
 		"columns": {}
-	}
+	},
+	"id": "af02f2d3-1889-4bf5-ba40-d0f99d33e28c",
+	"prevId": "2c3bca22-4be0-4516-bded-7c4f6151a6fc",
+	"views": {}
 }

--- a/api/drizzle/meta/0004_snapshot.json
+++ b/api/drizzle/meta/0004_snapshot.json
@@ -1,8 +1,8 @@
 {
 	"version": "6",
 	"dialect": "sqlite",
-	"id": "c78aa4ab-d351-4960-849b-45719681eaac",
-	"prevId": "2e774160-3f29-474d-b254-9b733a9b2bfc",
+	"id": "3a1556dd-c073-4160-8208-7bf80c11b74d",
+	"prevId": "c78aa4ab-d351-4960-849b-45719681eaac",
 	"tables": {
 		"article_labels": {
 			"name": "article_labels",
@@ -34,7 +34,7 @@
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.202Z\"'"
 				}
 			},
 			"indexes": {},
@@ -94,13 +94,20 @@
 					"autoincrement": false,
 					"default": false
 				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
 				"created_at": {
 					"name": "created_at",
 					"type": "integer",
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.201Z\"'"
 				},
 				"updated_at": {
 					"name": "updated_at",
@@ -108,7 +115,7 @@
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.201Z\"'"
 				}
 			},
 			"indexes": {},
@@ -140,7 +147,7 @@
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.201Z\"'"
 				}
 			},
 			"indexes": {
@@ -195,7 +202,7 @@
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.201Z\"'"
 				},
 				"updated_at": {
 					"name": "updated_at",
@@ -203,7 +210,7 @@
 					"primaryKey": false,
 					"notNull": true,
 					"autoincrement": false,
-					"default": "'\"2025-05-03T13:06:58.957Z\"'"
+					"default": "'\"2025-05-17T14:37:36.201Z\"'"
 				}
 			},
 			"indexes": {

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1746277800000,
 			"tag": "0003_joyous_adam_destine",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1747492656206,
+			"tag": "0004_old_eternity",
+			"breakpoints": true
 		}
 	]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -6,6 +6,7 @@ export const bookmarks = sqliteTable("bookmarks", {
 	url: text("url").notNull(),
 	title: text("title"),
 	isRead: integer("is_read", { mode: "boolean" }).notNull().default(false),
+	summary: text("summary"), // AI生成による記事要約
 	createdAt: integer("created_at", { mode: "timestamp" })
 		.notNull()
 		.default(new Date()),

--- a/api/src/interfaces/repository/bookmark.ts
+++ b/api/src/interfaces/repository/bookmark.ts
@@ -51,4 +51,18 @@ export interface IBookmarkRepository {
 	 * @returns ブックマークのマップ（ID => BookmarkWithLabel）
 	 */
 	findByIds(ids: number[]): Promise<Map<number, BookmarkWithLabel>>;
+
+	/**
+	 * 要約が未作成のブックマークを取得します。
+	 * @param limit 取得件数制限（デフォルト: 5）
+	 * @returns 要約なしのブックマーク配列
+	 */
+	findWithoutSummary(limit?: number): Promise<BookmarkWithLabel[]>;
+
+	/**
+	 * ブックマークの要約を更新します。
+	 * @param bookmarkId ブックマークID
+	 * @param summary 要約文
+	 */
+	updateSummary(bookmarkId: number, summary: string): Promise<void>;
 }

--- a/api/src/interfaces/service/bookmark.ts
+++ b/api/src/interfaces/service/bookmark.ts
@@ -30,4 +30,18 @@ export interface IBookmarkService {
 	 * @returns ラベルに紐づくブックマーク配列
 	 */
 	getBookmarksByLabel(labelName: string): Promise<BookmarkWithLabel[]>;
+
+	/**
+	 * 要約が未作成のブックマークを取得します。
+	 * @param limit 取得件数制限
+	 * @returns 要約なしのブックマーク配列
+	 */
+	getBookmarksWithoutSummary(limit?: number): Promise<BookmarkWithLabel[]>;
+
+	/**
+	 * ブックマークの要約を更新します。
+	 * @param bookmarkId ブックマークID
+	 * @param summary 要約文
+	 */
+	updateBookmarkSummary(bookmarkId: number, summary: string): Promise<void>;
 }

--- a/api/src/routes/bookmarks.ts
+++ b/api/src/routes/bookmarks.ts
@@ -49,6 +49,37 @@ export const createBookmarksRouter = (
 		}
 	});
 
+	// 要約なしのブックマークを取得
+	app.get("/without-summary", async (c) => {
+		const limit = c.req.query("limit");
+		const parsedLimit = limit ? Number.parseInt(limit, 10) : undefined;
+
+		if (limit && (Number.isNaN(parsedLimit) || parsedLimit <= 0)) {
+			return c.json(
+				{ success: false, message: "Invalid limit parameter" },
+				400,
+			);
+		}
+
+		try {
+			const bookmarks =
+				await bookmarkService.getBookmarksWithoutSummary(parsedLimit);
+			return c.json({
+				success: true,
+				bookmarks,
+			});
+		} catch (error) {
+			console.error("Failed to fetch bookmarks without summary:", error);
+			return c.json(
+				{
+					success: false,
+					message: "Failed to fetch bookmarks without summary",
+				},
+				500,
+			);
+		}
+	});
+
 	app.get("/unlabeled", async (c) => {
 		try {
 			const bookmarks = await bookmarkService.getUnlabeledBookmarks();
@@ -244,6 +275,54 @@ export const createBookmarksRouter = (
 			console.error("Failed to mark bookmark as read:", error);
 			return c.json(
 				{ success: false, message: "Failed to mark bookmark as read" },
+				500,
+			);
+		}
+	});
+
+	// ブックマークの要約を作成
+	app.post("/:id/summary", async (c) => {
+		try {
+			const id = Number.parseInt(c.req.param("id"));
+			if (Number.isNaN(id)) {
+				return c.json({ success: false, message: "Invalid bookmark ID" }, 400);
+			}
+
+			const body = await c.req.json<{ summary: string }>();
+			if (!body.summary || typeof body.summary !== "string") {
+				return c.json({ success: false, message: "Summary is required" }, 400);
+			}
+
+			await bookmarkService.updateBookmarkSummary(id, body.summary);
+			return c.json({ success: true });
+		} catch (error) {
+			console.error("Failed to update bookmark summary:", error);
+			return c.json(
+				{ success: false, message: "Failed to update bookmark summary" },
+				500,
+			);
+		}
+	});
+
+	// ブックマークの要約を更新
+	app.put("/:id/summary", async (c) => {
+		try {
+			const id = Number.parseInt(c.req.param("id"));
+			if (Number.isNaN(id)) {
+				return c.json({ success: false, message: "Invalid bookmark ID" }, 400);
+			}
+
+			const body = await c.req.json<{ summary: string }>();
+			if (!body.summary || typeof body.summary !== "string") {
+				return c.json({ success: false, message: "Summary is required" }, 400);
+			}
+
+			await bookmarkService.updateBookmarkSummary(id, body.summary);
+			return c.json({ success: true });
+		} catch (error) {
+			console.error("Failed to update bookmark summary:", error);
+			return c.json(
+				{ success: false, message: "Failed to update bookmark summary" },
 				500,
 			);
 		}

--- a/api/src/services/bookmark.ts
+++ b/api/src/services/bookmark.ts
@@ -166,4 +166,27 @@ export class DefaultBookmarkService implements IBookmarkService {
 			throw new Error("Failed to get bookmarks by label");
 		}
 	}
+
+	async getBookmarksWithoutSummary(
+		limit?: number,
+	): Promise<BookmarkWithLabel[]> {
+		try {
+			return await this.repository.findWithoutSummary(limit);
+		} catch (error) {
+			console.error("Failed to get bookmarks without summary:", error);
+			throw new Error("Failed to get bookmarks without summary");
+		}
+	}
+
+	async updateBookmarkSummary(
+		bookmarkId: number,
+		summary: string,
+	): Promise<void> {
+		try {
+			await this.repository.updateSummary(bookmarkId, summary);
+		} catch (error) {
+			console.error("Failed to update bookmark summary:", error);
+			throw new Error("Failed to update bookmark summary");
+		}
+	}
 }

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -11,7 +11,8 @@ interface Props {
 }
 
 export function BookmarkCard({ bookmark, onLabelClick }: Props) {
-	const { id, title, url, createdAt, isRead, isFavorite, label } = bookmark;
+	const { id, title, url, createdAt, isRead, isFavorite, label, summary } =
+		bookmark;
 	const formattedDate = new Date(createdAt).toLocaleDateString("ja-JP");
 
 	const { mutate: toggleFavorite, isPending: isTogglingFavorite } =
@@ -39,6 +40,21 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		if (!isRead) {
 			// 非同期で既読にする（結果を待たない）
 			markAsReadMutate(id);
+		}
+	};
+
+	// 要約をマークダウン形式でコピー
+	const handleCopySummary = async () => {
+		if (!summary) return;
+
+		const markdown = `## ${title || "タイトルなし"}\n\n${url}\n\n### 要約\n${summary}`;
+
+		try {
+			await navigator.clipboard.writeText(markdown);
+			// コピー成功の通知（オプション）
+			// TODO: トースト通知などを実装
+		} catch (error) {
+			console.error("Failed to copy summary:", error);
 		}
 	};
 
@@ -179,6 +195,67 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					{title || "タイトルなし"}
 				</a>
 			</h2>
+
+			{/* 要約表示エリア */}
+			{summary && (
+				<div className="mb-3 p-3 bg-gray-50 rounded-md border border-gray-200">
+					<div className="flex justify-between items-start mb-2">
+						<h4 className="text-sm font-semibold text-gray-700">要約</h4>
+						<button
+							type="button"
+							onClick={handleCopySummary}
+							className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+							title="要約をコピー"
+						>
+							<svg
+								className="w-4 h-4"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+								/>
+							</svg>
+							コピー
+						</button>
+					</div>
+					<div className="text-sm text-gray-600 space-y-1">
+						{summary
+							.split("\n")
+							.filter((line) => line.trim())
+							.map((line, index) => (
+								<p key={index}>{line}</p>
+							))}
+					</div>
+				</div>
+			)}
+
+			{/* 要約がない場合の表示 */}
+			{!summary && (
+				<div className="mb-3 p-3 bg-gray-50 rounded-md border border-dashed border-gray-300">
+					<div className="text-sm text-gray-500 flex items-center gap-2">
+						<svg
+							className="w-4 h-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+						<span>要約はClaude Desktop経由で作成できます</span>
+					</div>
+				</div>
+			)}
+
 			<p className="text-sm text-gray-600 line-clamp-1 mb-2" title={url}>
 				{url}
 			</p>

--- a/frontend/src/features/bookmarks/types.ts
+++ b/frontend/src/features/bookmarks/types.ts
@@ -6,6 +6,7 @@ export interface Bookmark {
 	title: string | null;
 	isRead: boolean;
 	isFavorite: boolean;
+	summary: string | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -322,6 +322,219 @@ server.tool(
 	},
 );
 
+// 9. Tool to get bookmarks without summary
+server.tool(
+	"getBookmarksWithoutSummary",
+	// Define input arguments schema using Zod
+	{
+		limit: z.number().int().positive().optional(),
+	},
+	async ({ limit }) => {
+		try {
+			const bookmarks = await apiClient.getBookmarksWithoutSummary(limit);
+			return {
+				content: [{ type: "text", text: JSON.stringify(bookmarks, null, 2) }],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in getBookmarksWithoutSummary tool (limit: ${limit}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to get bookmarks without summary: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
+// 10. Tool to save bookmark summary
+server.tool(
+	"saveBookmarkSummary",
+	// Define input arguments schema using Zod
+	{
+		bookmarkId: z.number().int().positive(),
+		summary: z.string().min(1),
+	},
+	async ({ bookmarkId, summary }) => {
+		try {
+			await apiClient.saveBookmarkSummary(bookmarkId, summary);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Successfully saved summary for bookmark ID ${bookmarkId}.`,
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in saveBookmarkSummary tool (bookmarkId: ${bookmarkId}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to save bookmark summary: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
+// 11. Tool to update bookmark summary
+server.tool(
+	"updateBookmarkSummary",
+	// Define input arguments schema using Zod
+	{
+		bookmarkId: z.number().int().positive(),
+		summary: z.string().min(1),
+	},
+	async ({ bookmarkId, summary }) => {
+		try {
+			await apiClient.updateBookmarkSummary(bookmarkId, summary);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Successfully updated summary for bookmark ID ${bookmarkId}.`,
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in updateBookmarkSummary tool (bookmarkId: ${bookmarkId}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to update bookmark summary: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
+// 12. Tool to get bookmark by ID
+server.tool(
+	"getBookmarkById",
+	// Define input arguments schema using Zod
+	{
+		bookmarkId: z.number().int().positive(),
+	},
+	async ({ bookmarkId }) => {
+		try {
+			const bookmark = await apiClient.getBookmarkById(bookmarkId);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Bookmark details: ${JSON.stringify(bookmark, null, 2)}`,
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in getBookmarkById tool (bookmarkId: ${bookmarkId}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to get bookmark: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
+// 13. Tool to generate summary
+server.tool(
+	"generateSummary",
+	// Define input arguments schema using Zod
+	{
+		bookmarkId: z.number().int().positive(),
+		articleContent: z.string().min(1),
+	},
+	async ({ bookmarkId, articleContent }) => {
+		try {
+			// LLMプロンプトの作成
+			const prompt = `
+以下の技術記事の要約を作成してください。tl;dr形式で3-5個のポイントに整理し、技術的な要点を重視してください。
+
+## 要約のフォーマット
+tl;dr
+- ポイント1（技術的な主要概念や手法）
+- ポイント2（実装上の重要な知見）
+- ポイント3（使用されている技術スタックや手法）
+- ポイント4（結果や成果、メリットなど）
+- ポイント5（応用可能性や注意点など）
+
+## 記事内容
+${articleContent}
+
+## 要約`;
+
+			// Note: 実際のLLM呼び出しは、Claude Desktop側で行われる想定
+			// このツールは要約生成のためのプロンプトを提供し、
+			// 生成された要約をAPIに保存する機能を提供する
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: `以下のプロンプトでLLMに要約を生成してください。生成された要約は saveBookmarkSummary ツールを使用して保存できます。\n\n${prompt}`,
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in generateSummary tool (bookmarkId: ${bookmarkId}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to generate summary prompt: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
 // --- End Tool Definition ---
 
 async function main() {


### PR DESCRIPTION
## 概要
Issue #373（記事要約機能 Phase 2）のコア機能実装です。

## 実装内容
- **データベース**: bookmarksテーブルにsummaryカラムを追加
- **API**: 要約関連エンドポイントの実装
  - GET /bookmarks/without-summary（要約なしブックマーク取得）
  - POST /bookmarks/:id/summary（要約作成）
  - PUT /bookmarks/:id/summary（要約更新）
- **MCP**: 要約管理ツールの実装
  - getBookmarksWithoutSummary
  - saveBookmarkSummary
  - updateBookmarkSummary
  - getBookmarkById
  - generateSummary（要約生成用プロンプト）
- **フロントエンド**: BookmarkCardの拡張
  - 要約表示エリア
  - マークダウン形式での要約コピー機能

## テスト計画
- [ ] DBマイグレーションの動作確認
- [ ] APIエンドポイントの動作確認
- [ ] MCP経由での要約生成・保存フローの確認
- [ ] フロントエンドでの要約表示・コピー機能の確認

Closes #373

🤖 Generated with [Claude Code](https://claude.ai/code)