### PR TITLE
✨ feat: 記事要約機能 Phase 2 - フロントエンド実装

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -4,6 +4,7 @@ import { useMarkBookmarkAsRead } from "@/features/bookmarks/queries/useMarkBookm
 import { useToggleFavoriteBookmark } from "@/features/bookmarks/queries/useToggleFavoriteBookmark";
 import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import { LabelDisplay } from "@/features/labels/components/LabelDisplay";
+import { BookmarkSummary } from "./BookmarkSummary";
 
 interface Props {
 	bookmark: BookmarkWithLabel;
@@ -11,7 +12,7 @@ interface Props {
 }
 
 export function BookmarkCard({ bookmark, onLabelClick }: Props) {
-	const { id, title, url, createdAt, isRead, isFavorite, label } = bookmark;
+	const { id, title, url, createdAt, isRead, isFavorite, label, summary } = bookmark;
 	const formattedDate = new Date(createdAt).toLocaleDateString("ja-JP");
 
 	const { mutate: toggleFavorite, isPending: isTogglingFavorite } =
@@ -46,7 +47,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		<article
 			className={`relative p-4 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
 				isRead ? "bg-gray-50" : ""
-			}`}
+			} ${summary ? "pb-6" : ""}`}
 		>
 			{/* ラベル表示 */}
 			{label && (
@@ -183,6 +184,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 				{url}
 			</p>
 			<p className="text-xs text-gray-500">{formattedDate}</p>
+			<BookmarkSummary summary={summary} />
 		</article>
 	);
 }

--- a/frontend/src/features/bookmarks/components/BookmarkSummary.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkSummary.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+	summary: string | null;
+	onCopy?: (success: boolean) => void;
+}
+
+export function BookmarkSummary({ summary, onCopy }: Props) {
+	const [showSummary, setShowSummary] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [copySuccess, setCopySuccess] = useState(false);
+
+	if (!summary) return null;
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(summary);
+			setCopySuccess(true);
+			onCopy?.(true);
+			setTimeout(() => setCopySuccess(false), 2000);
+		} catch (error) {
+			console.error("Failed to copy summary:", error);
+			onCopy?.(false);
+		}
+	};
+
+	const toggleSummary = () => {
+		setShowSummary(!showSummary);
+		if (!showSummary) {
+			setIsExpanded(false);
+		}
+	};
+
+	const summaryPreview = summary.length > 100 ? `${summary.slice(0, 100)}...` : summary;
+
+	return (
+		<div className="mt-3">
+			<button
+				type="button"
+				onClick={toggleSummary}
+				className="flex items-center text-sm text-blue-600 hover:text-blue-800"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					strokeWidth={1.5}
+					stroke="currentColor"
+					className={`w-4 h-4 mr-1 transition-transform ${showSummary ? "rotate-90" : ""}`}
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M8.25 4.5l7.5 7.5-7.5 7.5"
+					/>
+				</svg>
+				要約を{showSummary ? "隠す" : "表示"}
+			</button>
+
+			{showSummary && (
+				<div className="mt-2 p-3 bg-gray-50 border rounded-lg">
+					<div className="flex justify-between items-start mb-2">
+						<h3 className="font-semibold text-sm">記事の要約</h3>
+						<button
+							type="button"
+							onClick={handleCopy}
+							className={`ml-2 px-2 py-1 text-xs rounded transition-colors ${
+								copySuccess
+									? "bg-green-100 text-green-700"
+									: "bg-gray-100 text-gray-600 hover:bg-gray-200"
+							}`}
+						>
+							{copySuccess ? "コピー済み！" : "コピー"}
+						</button>
+					</div>
+
+					<div className="prose prose-sm max-w-none">
+						<p className="text-sm text-gray-700 whitespace-pre-wrap">
+							{isExpanded ? summary : summaryPreview}
+						</p>
+					</div>
+
+					{summary.length > 100 && (
+						<button
+							type="button"
+							onClick={() => setIsExpanded(!isExpanded)}
+							className="mt-2 text-xs text-blue-600 hover:text-blue-800"
+						>
+							{isExpanded ? "折りたたむ" : "全文を表示"}
+						</button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/features/bookmarks/types.ts
+++ b/frontend/src/features/bookmarks/types.ts
@@ -8,6 +8,9 @@ export interface Bookmark {
 	isFavorite: boolean;
 	createdAt: string;
 	updatedAt: string;
+	summary: string | null;
+	summaryCreatedAt: string | null;
+	summaryUpdatedAt: string | null;
 }
 
 export interface BookmarkWithLabel extends Bookmark {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -475,6 +475,66 @@ server.tool(
 	},
 );
 
+// 13. Tool to generate summary
+server.tool(
+	"generateSummary",
+	// Define input arguments schema using Zod
+	{
+		bookmarkId: z.number().int().positive(),
+		articleContent: z.string().min(1),
+	},
+	async ({ bookmarkId, articleContent }) => {
+		try {
+			// LLMプロンプトの作成
+			const prompt = `
+以下の技術記事の要約を作成してください。tl;dr形式で3-5個のポイントに整理し、技術的な要点を重視してください。
+
+## 要約のフォーマット
+tl;dr
+- ポイント1（技術的な主要概念や手法）
+- ポイント2（実装上の重要な知見）
+- ポイント3（使用されている技術スタックや手法）
+- ポイント4（結果や成果、メリットなど）
+- ポイント5（応用可能性や注意点など）
+
+## 記事内容
+${articleContent}
+
+## 要約`;
+
+			// Note: 実際のLLM呼び出しは、Claude Desktop側で行われる想定
+			// このツールは要約生成のためのプロンプトを提供し、
+			// 生成された要約をAPIに保存する機能を提供する
+			
+			return {
+				content: [
+					{
+						type: "text",
+						text: `以下のプロンプトでLLMに要約を生成してください。生成された要約は saveSummary ツールを使用して保存できます。\n\n${prompt}`,
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in generateSummary tool (bookmarkId: ${bookmarkId}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to generate summary prompt: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
 // --- End Tool Definition ---
 
 async function main() {


### PR DESCRIPTION
## 概要
Issue #373 「記事要約機能 - Phase2」の実装です。

## 実装内容
### フロントエンド要約表示機能
- 📱 `BookmarkSummary`コンポーネントを新規作成
- 🔗 `BookmarkCard`に要約表示機能を統合
- 📝 要約の折りたたみ/展開機能
- 📋 要約テキストのコピー機能

### 型定義の更新
- `Bookmark`型に要約関連フィールドを追加
  - `summary`: 要約本文
  - `summaryCreatedAt`: 要約作成日時
  - `summaryUpdatedAt`: 要約更新日時

### MCPツールの追加
- `generateSummary`ツールを実装（Phase 1で漏れていた分）

## 動作確認
- [x] フロントエンドで要約が表示されることを確認
- [x] 要約の展開/折りたたみが正常に動作
- [x] コピー機能が正常に動作

## テストプラン
- [ ] 要約がない記事では要約セクションが表示されないことを確認
- [ ] 要約がある記事で要約が適切に表示されることを確認
- [ ] 長い要約が省略表示されることを確認
- [ ] コピー機能で要約全文がクリップボードにコピーされることを確認

## 関連Issue
Fixes #373

🤖 Generated with [Claude Code](https://claude.ai/code)