### PR TITLE
#378 RSS読み込み機能 - 1. データベーススキーマの追加

### DIFF
--- a/api/drizzle/0005_stormy_shinko_yamashiro.sql
+++ b/api/drizzle/0005_stormy_shinko_yamashiro.sql
@@ -1,0 +1,95 @@
+CREATE TABLE `rss_batch_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`feed_id` integer NOT NULL,
+	`status` text NOT NULL,
+	`items_fetched` integer DEFAULT 0 NOT NULL,
+	`items_created` integer DEFAULT 0 NOT NULL,
+	`error_message` text,
+	`started_at` integer NOT NULL,
+	`finished_at` integer,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	FOREIGN KEY (`feed_id`) REFERENCES `rss_feeds`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `rss_feed_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`feed_id` integer NOT NULL,
+	`guid` text NOT NULL,
+	`url` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`published_at` integer,
+	`fetched_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	FOREIGN KEY (`feed_id`) REFERENCES `rss_feeds`(`id`) ON UPDATE no action ON DELETE no action,
+	UNIQUE(feed_id, guid)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_rss_feed_items_feed_published` ON `rss_feed_items` (`feed_id`, `published_at`);
+--> statement-breakpoint
+CREATE TABLE `rss_feeds` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`url` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`last_fetched_at` integer,
+	`next_fetch_at` integer,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `rss_feeds_url_unique` ON `rss_feeds` (`url`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_article_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`article_id` integer NOT NULL,
+	`label_id` integer NOT NULL,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	FOREIGN KEY (`article_id`) REFERENCES `bookmarks`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`label_id`) REFERENCES `labels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_article_labels`("id", "article_id", "label_id", "created_at") SELECT "id", "article_id", "label_id", "created_at" FROM `article_labels`;--> statement-breakpoint
+DROP TABLE `article_labels`;--> statement-breakpoint
+ALTER TABLE `__new_article_labels` RENAME TO `article_labels`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_bookmarks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`url` text NOT NULL,
+	`title` text,
+	`is_read` integer DEFAULT false NOT NULL,
+	`summary` text,
+	`summary_created_at` integer,
+	`summary_updated_at` integer,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_bookmarks`("id", "url", "title", "is_read", "summary", "summary_created_at", "summary_updated_at", "created_at", "updated_at") SELECT "id", "url", "title", "is_read", "summary", "summary_created_at", "summary_updated_at", "created_at", "updated_at" FROM `bookmarks`;--> statement-breakpoint
+DROP TABLE `bookmarks`;--> statement-breakpoint
+ALTER TABLE `__new_bookmarks` RENAME TO `bookmarks`;--> statement-breakpoint
+CREATE TABLE `__new_favorites` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`bookmark_id` integer NOT NULL,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	FOREIGN KEY (`bookmark_id`) REFERENCES `bookmarks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_favorites`("id", "bookmark_id", "created_at") SELECT "id", "bookmark_id", "created_at" FROM `favorites`;--> statement-breakpoint
+DROP TABLE `favorites`;--> statement-breakpoint
+ALTER TABLE `__new_favorites` RENAME TO `favorites`;--> statement-breakpoint
+CREATE UNIQUE INDEX `favorites_bookmark_id_unique` ON `favorites` (`bookmark_id`);--> statement-breakpoint
+CREATE TABLE `__new_labels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`created_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-05-17T16:21:48.391Z"' NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_labels`("id", "name", "description", "created_at", "updated_at") SELECT "id", "name", "description", "created_at", "updated_at" FROM `labels`;--> statement-breakpoint
+DROP TABLE `labels`;--> statement-breakpoint
+ALTER TABLE `__new_labels` RENAME TO `labels`;--> statement-breakpoint
+CREATE UNIQUE INDEX `labels_name_unique` ON `labels` (`name`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_rss_feed_items_feed_guid` ON `rss_feed_items` (`feed_id`, `guid`);

--- a/api/drizzle/meta/0005_snapshot.json
+++ b/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,499 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "c8c38527-5e79-459d-884d-cb2f8fd11f12",
+	"prevId": "9b261393-5bbd-4b87-9909-3463bb4ecf7e",
+	"tables": {
+		"article_labels": {
+			"name": "article_labels",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"article_id": {
+					"name": "article_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label_id": {
+					"name": "label_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"article_labels_article_id_bookmarks_id_fk": {
+					"name": "article_labels_article_id_bookmarks_id_fk",
+					"tableFrom": "article_labels",
+					"tableTo": "bookmarks",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"article_labels_label_id_labels_id_fk": {
+					"name": "article_labels_label_id_labels_id_fk",
+					"tableFrom": "article_labels",
+					"tableTo": "labels",
+					"columnsFrom": ["label_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"bookmarks": {
+			"name": "bookmarks",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_read": {
+					"name": "is_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary_created_at": {
+					"name": "summary_created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary_updated_at": {
+					"name": "summary_updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"favorites": {
+			"name": "favorites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"bookmark_id": {
+					"name": "bookmark_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {
+				"favorites_bookmark_id_unique": {
+					"name": "favorites_bookmark_id_unique",
+					"columns": ["bookmark_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"favorites_bookmark_id_bookmarks_id_fk": {
+					"name": "favorites_bookmark_id_bookmarks_id_fk",
+					"tableFrom": "favorites",
+					"tableTo": "bookmarks",
+					"columnsFrom": ["bookmark_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"labels": {
+			"name": "labels",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {
+				"labels_name_unique": {
+					"name": "labels_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rss_batch_logs": {
+			"name": "rss_batch_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"feed_id": {
+					"name": "feed_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"items_fetched": {
+					"name": "items_fetched",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"items_created": {
+					"name": "items_created",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"rss_batch_logs_feed_id_rss_feeds_id_fk": {
+					"name": "rss_batch_logs_feed_id_rss_feeds_id_fk",
+					"tableFrom": "rss_batch_logs",
+					"tableTo": "rss_feeds",
+					"columnsFrom": ["feed_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rss_feed_items": {
+			"name": "rss_feed_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"feed_id": {
+					"name": "feed_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"guid": {
+					"name": "guid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"rss_feed_items_feed_id_rss_feeds_id_fk": {
+					"name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+					"tableFrom": "rss_feed_items",
+					"tableTo": "rss_feeds",
+					"columnsFrom": ["feed_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rss_feeds": {
+			"name": "rss_feeds",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_fetch_at": {
+					"name": "next_fetch_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'\"2025-05-17T16:21:48.391Z\"'"
+				}
+			},
+			"indexes": {
+				"rss_feeds_url_unique": {
+					"name": "rss_feeds_url_unique",
+					"columns": ["url"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1747468934922,
 			"tag": "0004_woozy_zemo",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1747498908397,
+			"tag": "0005_stormy_shinko_yamashiro",
+			"breakpoints": true
 		}
 	]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -64,3 +64,62 @@ export type Label = typeof labels.$inferSelect;
 export type InsertLabel = typeof labels.$inferInsert;
 export type ArticleLabel = typeof articleLabels.$inferSelect;
 export type InsertArticleLabel = typeof articleLabels.$inferInsert;
+
+// RSSフィード
+export const rssFeeds = sqliteTable("rss_feeds", {
+	id: integer("id").primaryKey({ autoIncrement: true }),
+	name: text("name").notNull(),
+	url: text("url").notNull().unique(),
+	isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+	lastFetchedAt: integer("last_fetched_at", { mode: "timestamp" }),
+	nextFetchAt: integer("next_fetch_at", { mode: "timestamp" }),
+	createdAt: integer("created_at", { mode: "timestamp" })
+		.notNull()
+		.default(new Date()),
+	updatedAt: integer("updated_at", { mode: "timestamp" })
+		.notNull()
+		.default(new Date()),
+});
+
+// RSSフィードアイテム
+export const rssFeedItems = sqliteTable("rss_feed_items", {
+	id: integer("id").primaryKey({ autoIncrement: true }),
+	feedId: integer("feed_id")
+		.notNull()
+		.references(() => rssFeeds.id),
+	guid: text("guid").notNull(),
+	url: text("url").notNull(),
+	title: text("title").notNull(),
+	description: text("description"),
+	publishedAt: integer("published_at", { mode: "timestamp" }),
+	fetchedAt: integer("fetched_at", { mode: "timestamp" })
+		.notNull()
+		.default(new Date()),
+	createdAt: integer("created_at", { mode: "timestamp" })
+		.notNull()
+		.default(new Date()),
+});
+
+// RSSバッチログ
+export const rssBatchLogs = sqliteTable("rss_batch_logs", {
+	id: integer("id").primaryKey({ autoIncrement: true }),
+	feedId: integer("feed_id")
+		.notNull()
+		.references(() => rssFeeds.id),
+	status: text("status").notNull(),
+	itemsFetched: integer("items_fetched").notNull().default(0),
+	itemsCreated: integer("items_created").notNull().default(0),
+	errorMessage: text("error_message"),
+	startedAt: integer("started_at", { mode: "timestamp" }).notNull(),
+	finishedAt: integer("finished_at", { mode: "timestamp" }),
+	createdAt: integer("created_at", { mode: "timestamp" })
+		.notNull()
+		.default(new Date()),
+});
+
+export type RssFeed = typeof rssFeeds.$inferSelect;
+export type InsertRssFeed = typeof rssFeeds.$inferInsert;
+export type RssFeedItem = typeof rssFeedItems.$inferSelect;
+export type InsertRssFeedItem = typeof rssFeedItems.$inferInsert;
+export type RssBatchLog = typeof rssBatchLogs.$inferSelect;
+export type InsertRssBatchLog = typeof rssBatchLogs.$inferInsert;

--- a/api/src/repositories/rssBatchLog.ts
+++ b/api/src/repositories/rssBatchLog.ts
@@ -1,0 +1,58 @@
+import { desc, eq } from "drizzle-orm";
+import { type D1Database, drizzle } from "drizzle-orm/d1";
+import {
+	type InsertRssBatchLog,
+	type RssBatchLog,
+	rssBatchLogs,
+} from "../db/schema";
+
+export class RssBatchLogRepository {
+	private db;
+	public rssBatchLogsTable = rssBatchLogs;
+
+	constructor(d1Database: D1Database) {
+		this.db = drizzle(d1Database);
+	}
+
+	async create(log: InsertRssBatchLog): Promise<RssBatchLog> {
+		const result = await this.db
+			.insert(rssBatchLogs)
+			.values(log)
+			.returning()
+			.all();
+
+		return result[0];
+	}
+
+	async update(
+		id: number,
+		data: Partial<InsertRssBatchLog>,
+	): Promise<RssBatchLog> {
+		const result = await this.db
+			.update(rssBatchLogs)
+			.set(data)
+			.where(eq(rssBatchLogs.id, id))
+			.returning()
+			.all();
+
+		return result[0];
+	}
+
+	async findByFeedId(feedId: number): Promise<RssBatchLog[]> {
+		return await this.db
+			.select()
+			.from(rssBatchLogs)
+			.where(eq(rssBatchLogs.feedId, feedId))
+			.orderBy(desc(rssBatchLogs.createdAt))
+			.all();
+	}
+
+	async findLatestByFeedId(feedId: number): Promise<RssBatchLog | undefined> {
+		return await this.db
+			.select()
+			.from(rssBatchLogs)
+			.where(eq(rssBatchLogs.feedId, feedId))
+			.orderBy(desc(rssBatchLogs.createdAt))
+			.get();
+	}
+}

--- a/api/src/repositories/rssFeed.ts
+++ b/api/src/repositories/rssFeed.ts
@@ -1,0 +1,60 @@
+import { type SQL, eq } from "drizzle-orm";
+import { type D1Database, drizzle } from "drizzle-orm/d1";
+import { type InsertRssFeed, type RssFeed, rssFeeds } from "../db/schema";
+
+export class RssFeedRepository {
+	private db;
+	public rssFeedsTable = rssFeeds;
+
+	constructor(d1Database: D1Database) {
+		this.db = drizzle(d1Database);
+	}
+
+	async create(feed: InsertRssFeed): Promise<RssFeed> {
+		const result = await this.db
+			.insert(rssFeeds)
+			.values(feed)
+			.returning()
+			.all();
+
+		return result[0];
+	}
+
+	async findById(id: number): Promise<RssFeed | undefined> {
+		return await this.db
+			.select()
+			.from(rssFeeds)
+			.where(eq(rssFeeds.id, id))
+			.get();
+	}
+
+	async findByUrl(url: string): Promise<RssFeed | undefined> {
+		return await this.db
+			.select()
+			.from(rssFeeds)
+			.where(eq(rssFeeds.url, url))
+			.get();
+	}
+
+	async findAllActive(): Promise<RssFeed[]> {
+		return await this.db
+			.select()
+			.from(rssFeeds)
+			.where(eq(rssFeeds.isActive, true))
+			.all();
+	}
+
+	async update(id: number, data: Partial<InsertRssFeed>): Promise<RssFeed> {
+		const result = await this.db
+			.update(rssFeeds)
+			.set({
+				...data,
+				updatedAt: new Date(),
+			})
+			.where(eq(rssFeeds.id, id))
+			.returning()
+			.all();
+
+		return result[0];
+	}
+}

--- a/api/src/repositories/rssFeedItem.ts
+++ b/api/src/repositories/rssFeedItem.ts
@@ -1,0 +1,52 @@
+import { and, desc, eq } from "drizzle-orm";
+import { type D1Database, drizzle } from "drizzle-orm/d1";
+import {
+	type InsertRssFeedItem,
+	type RssFeedItem,
+	rssFeedItems,
+} from "../db/schema";
+
+export class RssFeedItemRepository {
+	private db;
+	public rssFeedItemsTable = rssFeedItems;
+
+	constructor(d1Database: D1Database) {
+		this.db = drizzle(d1Database);
+	}
+
+	async create(item: InsertRssFeedItem): Promise<RssFeedItem> {
+		const result = await this.db
+			.insert(rssFeedItems)
+			.values(item)
+			.returning()
+			.all();
+
+		return result[0];
+	}
+
+	async findByFeedIdAndGuid(
+		feedId: number,
+		guid: string,
+	): Promise<RssFeedItem | undefined> {
+		return await this.db
+			.select()
+			.from(rssFeedItems)
+			.where(and(eq(rssFeedItems.feedId, feedId), eq(rssFeedItems.guid, guid)))
+			.get();
+	}
+
+	async findByFeedId(feedId: number): Promise<RssFeedItem[]> {
+		return await this.db
+			.select()
+			.from(rssFeedItems)
+			.where(eq(rssFeedItems.feedId, feedId))
+			.orderBy(desc(rssFeedItems.publishedAt))
+			.all();
+	}
+
+	async createMany(items: InsertRssFeedItem[]): Promise<number> {
+		const result = await this.db.insert(rssFeedItems).values(items).all();
+
+		return items.length;
+	}
+}

--- a/api/tests/unit/repositories/rssBatchLog.test.ts
+++ b/api/tests/unit/repositories/rssBatchLog.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RssBatchLog } from "../../../src/db/schema";
+import { RssBatchLogRepository } from "../../../src/repositories/rssBatchLog";
+
+const mockDb = {
+	select: vi.fn().mockReturnThis(),
+	from: vi.fn().mockReturnThis(),
+	where: vi.fn().mockReturnThis(),
+	orderBy: vi.fn().mockReturnThis(),
+	all: vi.fn(),
+	get: vi.fn(),
+	insert: vi.fn().mockReturnThis(),
+	update: vi.fn().mockReturnThis(),
+	set: vi.fn().mockReturnThis(),
+	values: vi.fn().mockReturnThis(),
+	returning: vi.fn().mockReturnThis(),
+	delete: vi.fn().mockReturnThis(),
+};
+
+vi.mock("drizzle-orm/d1", () => ({
+	drizzle: vi.fn(() => mockDb),
+}));
+
+describe("RssBatchLogRepository", () => {
+	let rssBatchLogRepository: RssBatchLogRepository;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		const mockD1Database = {} as D1Database;
+		rssBatchLogRepository = new RssBatchLogRepository(mockD1Database);
+	});
+
+	describe("create", () => {
+		it("新しいバッチログを作成できる", async () => {
+			const newLog = {
+				feedId: 1,
+				status: "success",
+				itemsFetched: 10,
+				itemsCreated: 5,
+				startedAt: new Date(),
+			};
+
+			const expectedLog: RssBatchLog = {
+				id: 1,
+				feedId: 1,
+				status: "success",
+				itemsFetched: 10,
+				itemsCreated: 5,
+				errorMessage: null,
+				startedAt: newLog.startedAt,
+				finishedAt: null,
+				createdAt: new Date(),
+			};
+
+			mockDb.all.mockResolvedValueOnce([expectedLog]);
+
+			const result = await rssBatchLogRepository.create(newLog);
+
+			expect(mockDb.insert).toHaveBeenCalledWith(
+				rssBatchLogRepository.rssBatchLogsTable,
+			);
+			expect(mockDb.values).toHaveBeenCalledWith(newLog);
+			expect(mockDb.returning).toHaveBeenCalled();
+			expect(result).toEqual(expectedLog);
+		});
+	});
+
+	describe("update", () => {
+		it("バッチログを更新できる", async () => {
+			const id = 1;
+			const updateData = {
+				status: "error",
+				errorMessage: "フィードの取得に失敗しました",
+				finishedAt: new Date(),
+			};
+
+			const updatedLog: RssBatchLog = {
+				id: 1,
+				feedId: 1,
+				status: "error",
+				itemsFetched: 0,
+				itemsCreated: 0,
+				errorMessage: "フィードの取得に失敗しました",
+				startedAt: new Date(),
+				finishedAt: updateData.finishedAt,
+				createdAt: new Date(),
+			};
+
+			mockDb.all.mockResolvedValueOnce([updatedLog]);
+
+			const result = await rssBatchLogRepository.update(id, updateData);
+
+			expect(mockDb.update).toHaveBeenCalledWith(
+				rssBatchLogRepository.rssBatchLogsTable,
+			);
+			expect(mockDb.set).toHaveBeenCalledWith(updateData);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(mockDb.returning).toHaveBeenCalled();
+			expect(result).toEqual(updatedLog);
+		});
+	});
+
+	describe("findByFeedId", () => {
+		it("フィードIDでバッチログを取得できる", async () => {
+			const feedId = 1;
+			const expectedLogs: RssBatchLog[] = [
+				{
+					id: 1,
+					feedId: 1,
+					status: "success",
+					itemsFetched: 10,
+					itemsCreated: 5,
+					errorMessage: null,
+					startedAt: new Date(),
+					finishedAt: new Date(),
+					createdAt: new Date(),
+				},
+				{
+					id: 2,
+					feedId: 1,
+					status: "error",
+					itemsFetched: 0,
+					itemsCreated: 0,
+					errorMessage: "ネットワークエラー",
+					startedAt: new Date(),
+					finishedAt: new Date(),
+					createdAt: new Date(),
+				},
+			];
+
+			mockDb.all.mockResolvedValueOnce(expectedLogs);
+
+			const result = await rssBatchLogRepository.findByFeedId(feedId);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(
+				rssBatchLogRepository.rssBatchLogsTable,
+			);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(mockDb.orderBy).toHaveBeenCalled();
+			expect(result).toEqual(expectedLogs);
+		});
+	});
+
+	describe("findLatestByFeedId", () => {
+		it("フィードIDで最新のバッチログを取得できる", async () => {
+			const feedId = 1;
+			const expectedLog: RssBatchLog = {
+				id: 3,
+				feedId: 1,
+				status: "success",
+				itemsFetched: 15,
+				itemsCreated: 8,
+				errorMessage: null,
+				startedAt: new Date(),
+				finishedAt: new Date(),
+				createdAt: new Date(),
+			};
+
+			mockDb.get.mockResolvedValueOnce(expectedLog);
+
+			const result = await rssBatchLogRepository.findLatestByFeedId(feedId);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(
+				rssBatchLogRepository.rssBatchLogsTable,
+			);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(mockDb.orderBy).toHaveBeenCalled();
+			expect(result).toEqual(expectedLog);
+		});
+	});
+});

--- a/api/tests/unit/repositories/rssFeed.test.ts
+++ b/api/tests/unit/repositories/rssFeed.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RssFeed } from "../../../src/db/schema";
+import { RssFeedRepository } from "../../../src/repositories/rssFeed";
+
+const mockDb = {
+	select: vi.fn().mockReturnThis(),
+	from: vi.fn().mockReturnThis(),
+	where: vi.fn().mockReturnThis(),
+	orderBy: vi.fn().mockReturnThis(),
+	all: vi.fn(),
+	get: vi.fn(),
+	insert: vi.fn().mockReturnThis(),
+	update: vi.fn().mockReturnThis(),
+	set: vi.fn().mockReturnThis(),
+	values: vi.fn().mockReturnThis(),
+	returning: vi.fn().mockReturnThis(),
+	delete: vi.fn().mockReturnThis(),
+};
+
+vi.mock("drizzle-orm/d1", () => ({
+	drizzle: vi.fn(() => mockDb),
+}));
+
+describe("RssFeedRepository", () => {
+	let rssFeedRepository: RssFeedRepository;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		const mockD1Database = {} as D1Database;
+		rssFeedRepository = new RssFeedRepository(mockD1Database);
+	});
+
+	describe("create", () => {
+		it("新しいRSSフィードを作成できる", async () => {
+			const newFeed = {
+				name: "Tech Blog",
+				url: "https://example.com/feed.xml",
+				isActive: true,
+			};
+
+			const expectedFeed: RssFeed = {
+				id: 1,
+				name: "Tech Blog",
+				url: "https://example.com/feed.xml",
+				isActive: true,
+				lastFetchedAt: null,
+				nextFetchAt: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			mockDb.all.mockResolvedValueOnce([expectedFeed]);
+
+			const result = await rssFeedRepository.create(newFeed);
+
+			expect(mockDb.insert).toHaveBeenCalledWith(
+				rssFeedRepository.rssFeedsTable,
+			);
+			expect(mockDb.values).toHaveBeenCalledWith(newFeed);
+			expect(mockDb.returning).toHaveBeenCalled();
+			expect(result).toEqual(expectedFeed);
+		});
+	});
+
+	describe("findById", () => {
+		it("IDでRSSフィードを取得できる", async () => {
+			const expectedFeed: RssFeed = {
+				id: 1,
+				name: "Tech Blog",
+				url: "https://example.com/feed.xml",
+				isActive: true,
+				lastFetchedAt: null,
+				nextFetchAt: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			mockDb.get.mockResolvedValueOnce(expectedFeed);
+
+			const result = await rssFeedRepository.findById(1);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(rssFeedRepository.rssFeedsTable);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(result).toEqual(expectedFeed);
+		});
+	});
+
+	describe("findByUrl", () => {
+		it("URLでRSSフィードを取得できる", async () => {
+			const url = "https://example.com/feed.xml";
+			const expectedFeed: RssFeed = {
+				id: 1,
+				name: "Tech Blog",
+				url: url,
+				isActive: true,
+				lastFetchedAt: null,
+				nextFetchAt: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			mockDb.get.mockResolvedValueOnce(expectedFeed);
+
+			const result = await rssFeedRepository.findByUrl(url);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(rssFeedRepository.rssFeedsTable);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(result).toEqual(expectedFeed);
+		});
+	});
+
+	describe("findAllActive", () => {
+		it("アクティブなRSSフィードをすべて取得できる", async () => {
+			const expectedFeeds: RssFeed[] = [
+				{
+					id: 1,
+					name: "Tech Blog",
+					url: "https://example.com/feed.xml",
+					isActive: true,
+					lastFetchedAt: null,
+					nextFetchAt: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+				{
+					id: 2,
+					name: "News Feed",
+					url: "https://news.com/feed.xml",
+					isActive: true,
+					lastFetchedAt: null,
+					nextFetchAt: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			];
+
+			mockDb.all.mockResolvedValueOnce(expectedFeeds);
+
+			const result = await rssFeedRepository.findAllActive();
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(rssFeedRepository.rssFeedsTable);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(result).toEqual(expectedFeeds);
+		});
+	});
+
+	describe("update", () => {
+		it("RSSフィードを更新できる", async () => {
+			const id = 1;
+			const updateData = {
+				name: "Updated Tech Blog",
+				lastFetchedAt: new Date(),
+			};
+
+			const updatedFeed: RssFeed = {
+				id: 1,
+				name: "Updated Tech Blog",
+				url: "https://example.com/feed.xml",
+				isActive: true,
+				lastFetchedAt: updateData.lastFetchedAt,
+				nextFetchAt: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			mockDb.all.mockResolvedValueOnce([updatedFeed]);
+
+			const result = await rssFeedRepository.update(id, updateData);
+
+			expect(mockDb.update).toHaveBeenCalledWith(
+				rssFeedRepository.rssFeedsTable,
+			);
+			expect(mockDb.set).toHaveBeenCalledWith({
+				...updateData,
+				updatedAt: expect.any(Date),
+			});
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(mockDb.returning).toHaveBeenCalled();
+			expect(result).toEqual(updatedFeed);
+		});
+	});
+});

--- a/api/tests/unit/repositories/rssFeedItem.test.ts
+++ b/api/tests/unit/repositories/rssFeedItem.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RssFeedItem } from "../../../src/db/schema";
+import { RssFeedItemRepository } from "../../../src/repositories/rssFeedItem";
+
+const mockDb = {
+	select: vi.fn().mockReturnThis(),
+	from: vi.fn().mockReturnThis(),
+	where: vi.fn().mockReturnThis(),
+	orderBy: vi.fn().mockReturnThis(),
+	all: vi.fn(),
+	get: vi.fn(),
+	insert: vi.fn().mockReturnThis(),
+	update: vi.fn().mockReturnThis(),
+	set: vi.fn().mockReturnThis(),
+	values: vi.fn().mockReturnThis(),
+	returning: vi.fn().mockReturnThis(),
+	delete: vi.fn().mockReturnThis(),
+};
+
+vi.mock("drizzle-orm/d1", () => ({
+	drizzle: vi.fn(() => mockDb),
+}));
+
+describe("RssFeedItemRepository", () => {
+	let rssFeedItemRepository: RssFeedItemRepository;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		const mockD1Database = {} as D1Database;
+		rssFeedItemRepository = new RssFeedItemRepository(mockD1Database);
+	});
+
+	describe("create", () => {
+		it("新しいRSSフィードアイテムを作成できる", async () => {
+			const newItem = {
+				feedId: 1,
+				guid: "item-123",
+				url: "https://example.com/article/123",
+				title: "新しい記事",
+				description: "記事の概要",
+				publishedAt: new Date(),
+			};
+
+			const expectedItem: RssFeedItem = {
+				id: 1,
+				feedId: 1,
+				guid: "item-123",
+				url: "https://example.com/article/123",
+				title: "新しい記事",
+				description: "記事の概要",
+				publishedAt: newItem.publishedAt,
+				fetchedAt: new Date(),
+				createdAt: new Date(),
+			};
+
+			mockDb.all.mockResolvedValueOnce([expectedItem]);
+
+			const result = await rssFeedItemRepository.create(newItem);
+
+			expect(mockDb.insert).toHaveBeenCalledWith(
+				rssFeedItemRepository.rssFeedItemsTable,
+			);
+			expect(mockDb.values).toHaveBeenCalledWith(newItem);
+			expect(mockDb.returning).toHaveBeenCalled();
+			expect(result).toEqual(expectedItem);
+		});
+	});
+
+	describe("findByFeedIdAndGuid", () => {
+		it("フィードIDとGUIDでアイテムを取得できる", async () => {
+			const feedId = 1;
+			const guid = "item-123";
+			const expectedItem: RssFeedItem = {
+				id: 1,
+				feedId: 1,
+				guid: "item-123",
+				url: "https://example.com/article/123",
+				title: "新しい記事",
+				description: "記事の概要",
+				publishedAt: new Date(),
+				fetchedAt: new Date(),
+				createdAt: new Date(),
+			};
+
+			mockDb.get.mockResolvedValueOnce(expectedItem);
+
+			const result = await rssFeedItemRepository.findByFeedIdAndGuid(
+				feedId,
+				guid,
+			);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(
+				rssFeedItemRepository.rssFeedItemsTable,
+			);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(result).toEqual(expectedItem);
+		});
+	});
+
+	describe("findByFeedId", () => {
+		it("フィードIDでアイテムを取得できる", async () => {
+			const feedId = 1;
+			const expectedItems: RssFeedItem[] = [
+				{
+					id: 1,
+					feedId: 1,
+					guid: "item-123",
+					url: "https://example.com/article/123",
+					title: "新しい記事1",
+					description: "記事の概要1",
+					publishedAt: new Date(),
+					fetchedAt: new Date(),
+					createdAt: new Date(),
+				},
+				{
+					id: 2,
+					feedId: 1,
+					guid: "item-124",
+					url: "https://example.com/article/124",
+					title: "新しい記事2",
+					description: "記事の概要2",
+					publishedAt: new Date(),
+					fetchedAt: new Date(),
+					createdAt: new Date(),
+				},
+			];
+
+			mockDb.all.mockResolvedValueOnce(expectedItems);
+
+			const result = await rssFeedItemRepository.findByFeedId(feedId);
+
+			expect(mockDb.select).toHaveBeenCalled();
+			expect(mockDb.from).toHaveBeenCalledWith(
+				rssFeedItemRepository.rssFeedItemsTable,
+			);
+			expect(mockDb.where).toHaveBeenCalled();
+			expect(mockDb.orderBy).toHaveBeenCalled();
+			expect(result).toEqual(expectedItems);
+		});
+	});
+
+	describe("createMany", () => {
+		it("複数のアイテムを一括作成できる", async () => {
+			const newItems = [
+				{
+					feedId: 1,
+					guid: "item-123",
+					url: "https://example.com/article/123",
+					title: "新しい記事1",
+					description: "記事の概要1",
+					publishedAt: new Date(),
+				},
+				{
+					feedId: 1,
+					guid: "item-124",
+					url: "https://example.com/article/124",
+					title: "新しい記事2",
+					description: "記事の概要2",
+					publishedAt: new Date(),
+				},
+			];
+
+			mockDb.all.mockResolvedValueOnce([{ count: 2 }]);
+
+			const result = await rssFeedItemRepository.createMany(newItems);
+
+			expect(mockDb.insert).toHaveBeenCalledWith(
+				rssFeedItemRepository.rssFeedItemsTable,
+			);
+			expect(mockDb.values).toHaveBeenCalledWith(newItems);
+			expect(result).toEqual(2);
+		});
+	});
+});


### PR DESCRIPTION
## 概要
RSS読み込み機能に必要な基本的なデータベーステーブルを作成するマイグレーションファイルを追加しました。

## Summary
- RSS機能の基盤となるデータベーススキーマとリポジトリ層を実装
- TDDアプローチに従い、テストを先に実装してからリポジトリを作成

## 実装内容
- ✅ マイグレーションファイル（RSS関連テーブル）の作成
  - `rss_feeds` テーブル
  - `rss_feed_items` テーブル
  - `rss_batch_logs` テーブル
- ✅ `schema.ts`にテーブル定義を追加
- ✅ 各テーブルのリポジトリクラスを実装
- ✅ TDDに従ってテストを先行実装
- ✅ ローカルでマイグレーションを実行して動作確認

## Test plan
- ✅ 実装したテストが正常に動作することを確認
- ✅ マイグレーションがローカル環境で正常に適用されることを確認
- ✅ コードがリントとタイプチェックを通過することを確認

Closes #378

🤖 Generated with [Claude Code](https://claude.ai/code)