### PR TITLE
📚 docs: MCPのREADMEを更新し、要約管理機能を追加

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,14 +1,27 @@
-# Effective Yomimono Labeler MCP Server
+# Effective Yomimono MCP Server
 
-This directory contains the MCP (Model Context Protocol) server responsible for automatically labeling saved articles in the Effective Yomimono application. It interacts with the backend API to fetch unlabeled articles and assign labels based on predefined logic (currently placeholder, intended for LLM integration).
+This directory contains the MCP (Model Context Protocol) server that provides tools for article labeling and summary management in the Effective Yomimono application. It interacts with the backend API to manage bookmarks, labels, and summaries.
 
 ## 概要
 
-このサーバーは以下の3つのツールを公開します：
+このサーバーは以下のツールを公開します：
 
+### ラベル管理ツール
 - **`getUnlabeledArticles`**: ラベル付けされていない記事をAPIから取得します。（引数なし）
 - **`getLabels`**: 既存のラベル一覧をAPIから取得します。（引数なし）
-- **`assignLabel`**: 指定された記事IDに指定されたラベル名をAPI経由で割り当てます。（引数: `articleId`, `labelName`）
+- **`assignLabel`**: 指定された記事IDに指定されたラベル名をAPI経由で割り当てます。（引数: `articleId`, `labelName`, `description`）
+- **`createLabel`**: 新しいラベルを作成します。（引数: `labelName`, `description`）
+- **`getLabelById`**: 特定のラベルを取得します。（引数: `labelId`）
+- **`deleteLabel`**: ラベルを削除します。（引数: `labelId`）
+- **`updateLabelDescription`**: ラベルの説明を更新します。（引数: `labelId`, `description`）
+- **`assignLabelsToMultipleArticles`**: 複数の記事に一括でラベルを付与します。（引数: `articleIds`, `labelName`, `description`）
+
+### 要約管理ツール
+- **`getBookmarksWithoutSummary`**: 要約がないブックマークを取得します。（引数: `limit`, `orderBy`）
+- **`saveSummary`**: 生成した要約をブックマークに保存します。（引数: `bookmarkId`, `summary`）
+- **`updateSummary`**: 既存の要約を更新します。（引数: `bookmarkId`, `summary`）
+- **`getBookmarkById`**: 特定のブックマークを取得します。（引数: `bookmarkId`）
+- **`generateSummary`**: ブックマークの要約を生成します（現在は仮実装）。（引数: `bookmarkId`, `includeKeyPoints`, `maxLength`）
 
 ## Connecting with a Client
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "mcp",
+	"version": "0.3.0",
 	"module": "index.ts",
 	"type": "module",
 	"private": true,


### PR DESCRIPTION
## 概要
MCPのREADMEを更新し、既に実装済みの要約管理機能をドキュメントに追加しました。

## Summary
- MCPのREADMEに要約管理ツールのドキュメントを追加
- package.jsonにバージョン0.3.0を追加

## 変更内容
- ✅ READMEに要約管理ツールの説明を追加
  - `getBookmarksWithoutSummary`
  - `saveSummary`
  - `updateSummary`
  - `getBookmarkById`
  - `generateSummary`
- ✅ プロジェクトのタイトルを「Effective Yomimono MCP Server」に更新
- ✅ package.jsonにバージョン情報を追加

## Test plan
- ✅ ドキュメントの整合性を確認
- ✅ 既存のツールリストが正しく記載されていることを確認

Closes #377

🤖 Generated with [Claude Code](https://claude.ai/code)