### PR TITLE
✨ feat: ブックマークカードに記事IDコピーボタンを追加

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -36,6 +36,7 @@ export function BookmarkCard({
 		useToggleFavoriteBookmark();
 	const { mutate: markAsReadMutate, isPending: isMarkingAsRead } =
 		useMarkBookmarkAsRead();
+	const [isCopied, setIsCopied] = useState(false);
 
 	const handleFavoriteToggle = () => {
 		toggleFavorite({ id, isCurrentlyFavorite: isFavorite });
@@ -72,6 +73,17 @@ export function BookmarkCard({
 		}
 	};
 
+	// IDコピー処理
+	const handleCopyId = async () => {
+		try {
+			await navigator.clipboard.writeText(id.toString());
+			setIsCopied(true);
+			setTimeout(() => setIsCopied(false), 2000); // 2秒後にリセット
+		} catch (error) {
+			console.error("クリップボードへのコピーに失敗しました", error);
+		}
+	};
+
 	return (
 		<article
 			className={`relative p-4 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
@@ -84,6 +96,50 @@ export function BookmarkCard({
 					<LabelDisplay label={label} onClick={onLabelClick} />
 				</div>
 			)}
+
+			{/* IDコピーボタン */}
+			<button
+				type="button"
+				onClick={handleCopyId}
+				className={`absolute bottom-2 right-28 p-1 rounded-full transition-colors ${
+					isCopied
+						? "text-green-500 hover:text-green-600"
+						: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
+				}`}
+				title={isCopied ? "コピーしました！" : `ID: ${id}をコピー`}
+			>
+				{isCopied ? (
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						strokeWidth={1.5}
+						stroke="currentColor"
+						className="w-6 h-6"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M9 12.75L11.25 15 15 9.75m6-1.5c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
+						/>
+					</svg>
+				) : (
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						strokeWidth={1.5}
+						stroke="currentColor"
+						className="w-6 h-6"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+						/>
+					</svg>
+				)}
+			</button>
 
 			{/* お気に入りボタン */}
 			<button


### PR DESCRIPTION
## 概要
- MCPで要約を作成する際に記事IDを指定しやすくするため、ブックマークカードにIDコピーボタンを追加しました
- クリップボードにワンクリックでコピーできます
- コピー成功時は視覚的フィードバックを表示します

## テスト方法
- [ ] 開発サーバーを起動し、ブックマーク一覧を表示
- [ ] 各ブックマークの右下に表示されるIDコピーボタンをクリック
- [ ] クリップボードにIDがコピーされることを確認
- [ ] コピー成功フィードバックが表示されることを確認

## 関連issue
- Closes #409

🤖 Generated with [Claude Code](https://claude.ai/code)