### PR TITLE
✨ feat: 要約なしブックマーク取得APIエンドポイントを実装 #376

### DIFF
--- a/api/src/interfaces/repository/bookmark.ts
+++ b/api/src/interfaces/repository/bookmark.ts
@@ -56,11 +56,13 @@ export interface IBookmarkRepository {
 	 * 要約がないブックマークを取得します。
 	 * @param limit - 取得する件数の上限。
 	 * @param orderBy - ソート順（createdAt または readAt）。
+	 * @param offset - 取得開始位置。
 	 * @returns 要約がないブックマークの配列。
 	 */
 	findWithoutSummary(
 		limit?: number,
 		orderBy?: "createdAt" | "readAt",
+		offset?: number,
 	): Promise<BookmarkWithLabel[]>;
 
 	/**

--- a/api/src/interfaces/service/bookmark.ts
+++ b/api/src/interfaces/service/bookmark.ts
@@ -30,4 +30,17 @@ export interface IBookmarkService {
 	 * @returns ラベルに紐づくブックマーク配列
 	 */
 	getBookmarksByLabel(labelName: string): Promise<BookmarkWithLabel[]>;
+
+	/**
+	 * 要約がないブックマークを取得します。
+	 * @param limit 取得件数の上限
+	 * @param orderBy ソート順（createdAt または readAt）
+	 * @param offset 取得開始位置
+	 * @returns 要約がないブックマークのリスト
+	 */
+	getBookmarksWithoutSummary(
+		limit?: number,
+		orderBy?: "createdAt" | "readAt",
+		offset?: number,
+	): Promise<BookmarkWithLabel[]>;
 }

--- a/api/src/repositories/bookmark.ts
+++ b/api/src/repositories/bookmark.ts
@@ -403,11 +403,13 @@ export class DrizzleBookmarkRepository implements IBookmarkRepository {
 	 * 要約がないブックマークを取得します。
 	 * @param limit - 取得する件数の上限。
 	 * @param orderBy - ソート順（createdAt または readAt）。
+	 * @param offset - 取得開始位置。
 	 * @returns 要約がないブックマークの配列。
 	 */
 	async findWithoutSummary(
 		limit = 10,
 		orderBy: "createdAt" | "readAt" = "createdAt",
+		offset = 0,
 	): Promise<BookmarkWithLabel[]> {
 		try {
 			const query = this.db
@@ -421,7 +423,8 @@ export class DrizzleBookmarkRepository implements IBookmarkRepository {
 				.leftJoin(articleLabels, eq(bookmarks.id, articleLabels.articleId))
 				.leftJoin(labels, eq(articleLabels.labelId, labels.id))
 				.where(isNull(bookmarks.summary))
-				.limit(limit);
+				.limit(limit)
+				.offset(offset);
 
 			// ソート順を適用
 			const sortedQuery =

--- a/api/src/services/bookmark.ts
+++ b/api/src/services/bookmark.ts
@@ -166,4 +166,17 @@ export class DefaultBookmarkService implements IBookmarkService {
 			throw new Error("Failed to get bookmarks by label");
 		}
 	}
+
+	async getBookmarksWithoutSummary(
+		limit = 10,
+		orderBy: "createdAt" | "readAt" = "createdAt",
+		offset = 0,
+	): Promise<BookmarkWithLabel[]> {
+		try {
+			return await this.repository.findWithoutSummary(limit, orderBy, offset);
+		} catch (error) {
+			console.error("Failed to get bookmarks without summary:", error);
+			throw new Error("Failed to get bookmarks without summary");
+		}
+	}
 }

--- a/api/tests/unit/routes/bookmarks-without-summary.test.ts
+++ b/api/tests/unit/routes/bookmarks-without-summary.test.ts
@@ -1,0 +1,221 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IBookmarkRepository } from "../../../src/interfaces/repository/bookmark";
+import type { ILabelService } from "../../../src/interfaces/service/label";
+import { createBookmarksRouter } from "../../../src/routes/bookmarks";
+import { DefaultBookmarkService } from "../../../src/services/bookmark";
+
+describe("GET /bookmarks/without-summary", () => {
+	let mockBookmarkRepository: IBookmarkRepository;
+	let mockLabelService: ILabelService;
+	let bookmarkService: DefaultBookmarkService;
+	let app: Hono;
+
+	beforeEach(() => {
+		// Mock repository
+		mockBookmarkRepository = {
+			findWithoutSummary: vi.fn(),
+			createMany: vi.fn(),
+			findUnread: vi.fn(),
+			findByUrls: vi.fn(),
+			markAsRead: vi.fn(),
+			countUnread: vi.fn(),
+			countTodayRead: vi.fn(),
+			addToFavorites: vi.fn(),
+			removeFromFavorites: vi.fn(),
+			getFavoriteBookmarks: vi.fn(),
+			isFavorite: vi.fn(),
+			findRecentlyRead: vi.fn(),
+			findUnlabeled: vi.fn(),
+			findByLabelName: vi.fn(),
+			findById: vi.fn(),
+			findByIds: vi.fn(),
+			updateSummary: vi.fn(),
+		};
+
+		// Mock label service
+		mockLabelService = {
+			getAllLabels: vi.fn(),
+			assignLabel: vi.fn(),
+			assignLabelsToMultipleArticles: vi.fn(),
+		};
+
+		// Create services
+		bookmarkService = new DefaultBookmarkService(mockBookmarkRepository);
+
+		// Create app
+		app = new Hono();
+		const bookmarksRouter = createBookmarksRouter(
+			bookmarkService,
+			mockLabelService,
+		);
+		app.route("/bookmarks", bookmarksRouter);
+	});
+
+	it("デフォルトパラメータで要約なしブックマークを取得する", async () => {
+		const mockBookmarks = [
+			{
+				id: 1,
+				url: "https://example.com/article1",
+				title: "記事1",
+				isRead: false,
+				createdAt: new Date("2024-01-01"),
+				updatedAt: new Date("2024-01-01"),
+				readAt: null,
+				summary: null,
+				summaryCreatedAt: null,
+				summaryUpdatedAt: null,
+				isFavorite: false,
+				label: null,
+			},
+			{
+				id: 2,
+				url: "https://example.com/article2",
+				title: "記事2",
+				isRead: true,
+				createdAt: new Date("2024-01-02"),
+				updatedAt: new Date("2024-01-02"),
+				readAt: new Date("2024-01-02"),
+				summary: null,
+				summaryCreatedAt: null,
+				summaryUpdatedAt: null,
+				isFavorite: true,
+				label: null,
+			},
+		];
+
+		(
+			mockBookmarkRepository.findWithoutSummary as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockBookmarks);
+
+		// Create a mock request for testing
+		const res = await app.request("/bookmarks/without-summary");
+
+		expect(res.status).toBe(200);
+		expect(mockBookmarkRepository.findWithoutSummary).toHaveBeenCalledWith(
+			6, // limit + 1 for pagination (default is 5)
+			"createdAt", // default orderBy
+			0, // default offset
+		);
+
+		const json = await res.json();
+		expect(json).toMatchObject({
+			bookmarks: [
+				{
+					id: 1,
+					url: "https://example.com/article1",
+					title: "記事1",
+					createdAt: "2024-01-01T00:00:00.000Z",
+					readAt: null,
+					isFavorite: false,
+				},
+				{
+					id: 2,
+					url: "https://example.com/article2",
+					title: "記事2",
+					createdAt: "2024-01-02T00:00:00.000Z",
+					readAt: "2024-01-02T00:00:00.000Z",
+					isFavorite: true,
+				},
+			],
+			total: 2,
+			hasMore: false,
+		});
+	});
+
+	it("パラメータ付きで要約なしブックマークを取得する", async () => {
+		const mockBookmarks = [
+			{
+				id: 1,
+				url: "https://example.com/article1",
+				title: "記事1",
+				isRead: false,
+				createdAt: new Date("2024-01-01"),
+				updatedAt: new Date("2024-01-01"),
+				readAt: null,
+				summary: null,
+				summaryCreatedAt: null,
+				summaryUpdatedAt: null,
+				isFavorite: false,
+				label: null,
+			},
+		];
+
+		(
+			mockBookmarkRepository.findWithoutSummary as ReturnType<typeof vi.fn>
+		).mockResolvedValue(mockBookmarks);
+
+		const res = await app.request(
+			"/bookmarks/without-summary?limit=5&orderBy=readAt&offset=10",
+		);
+
+		expect(res.status).toBe(200);
+		expect(mockBookmarkRepository.findWithoutSummary).toHaveBeenCalledWith(
+			6, // limit + 1
+			"readAt",
+			10,
+		);
+
+		const json = await res.json();
+		expect(json).toMatchObject({
+			bookmarks: [
+				{
+					id: 1,
+					url: "https://example.com/article1",
+					title: "記事1",
+					isFavorite: false,
+				},
+			],
+			total: 11,
+			hasMore: false,
+		});
+	});
+
+	it("無効なlimitパラメータでエラーを返す", async () => {
+		const res = await app.request("/bookmarks/without-summary?limit=0");
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json).toMatchObject({
+			success: false,
+			message: "Invalid limit parameter",
+		});
+	});
+
+	it("無効なoffsetパラメータでエラーを返す", async () => {
+		const res = await app.request("/bookmarks/without-summary?offset=-1");
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json).toMatchObject({
+			success: false,
+			message: "Invalid offset parameter",
+		});
+	});
+
+	it("無効なorderByパラメータでエラーを返す", async () => {
+		const res = await app.request("/bookmarks/without-summary?orderBy=invalid");
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json).toMatchObject({
+			success: false,
+			message: "Invalid orderBy parameter",
+		});
+	});
+
+	it("エラー処理が正しく動作する", async () => {
+		(
+			mockBookmarkRepository.findWithoutSummary as ReturnType<typeof vi.fn>
+		).mockRejectedValue(new Error("Database error"));
+
+		const res = await app.request("/bookmarks/without-summary");
+
+		expect(res.status).toBe(500);
+		const json = await res.json();
+		expect(json).toMatchObject({
+			success: false,
+			message: "Failed to fetch bookmarks without summary",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- GET /bookmarks/without-summary APIエンドポイントを実装
- ページネーション対応（limit, offset, orderByパラメータ）を追加
- 要約なしのブックマークを効率的に取得可能に

## Implementation Details
- repository層: `findWithoutSummary`にoffsetパラメータを追加
- service層: `getBookmarksWithoutSummary`メソッドを実装
- routes層: 新しいエンドポイントを追加し、パラメータバリデーションを実装
- 正常系テストケースを作成

## Test plan
- [x] 単体テストが全て通過
- [x] リント・フォーマットチェック通過
- [ ] APIエンドポイントの動作確認
- [ ] パラメータバリデーションの確認

Closes #376

🤖 Generated with [Claude Code](https://claude.ai/code)