### PR TITLE
✨ feat: MCP Serverにラベル別未読記事取得ツールを追加

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,6 +22,7 @@ This directory contains the MCP (Model Context Protocol) server that provides to
 - **`updateSummary`**: 既存の要約を更新します。（引数: `bookmarkId`, `summary`）
 - **`getBookmarkById`**: 特定のブックマークを取得します。（引数: `bookmarkId`）
 - **`generateSummary`**: ブックマークの要約を生成します（現在は仮実装）。（引数: `bookmarkId`, `includeKeyPoints`, `maxLength`）
+- **`getUnreadArticlesByLabel`**: 指定されたラベルの未読記事を取得します。（引数: `labelName`）
 
 ## Connecting with a Client
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mcp",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"module": "index.ts",
 	"type": "module",
 	"private": true,

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -10,7 +10,7 @@ dotenv.config();
 // Create an MCP server instance
 const server = new McpServer({
 	name: "EffectiveYomimonoLabeler", // Descriptive name for the server
-	version: "0.3.0", // Updated with generateSummary tool
+	version: "0.4.0", // Updated with getUnreadArticlesByLabel tool
 });
 
 // --- Tool Definitions ---
@@ -561,6 +561,44 @@ ${
 					{
 						type: "text",
 						text: `Failed to generate summary: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
+// 14. Tool to get unread articles by label
+server.tool(
+	"getUnreadArticlesByLabel",
+	{
+		labelName: z.string().min(1),
+	},
+	async ({ labelName }) => {
+		try {
+			const articles = await apiClient.getUnreadArticlesByLabel(labelName);
+			return {
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(articles, null, 2),
+					},
+				],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in getUnreadArticlesByLabel tool (labelName: ${labelName}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to get unread articles by label: ${errorMessage}`,
 					},
 				],
 				isError: true,

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -570,3 +570,28 @@ export async function updateSummary(bookmarkId: number, summary: string) {
 	}
 	return parsed.data.bookmark;
 }
+
+/**
+ * ラベルで未読記事を取得します
+ * @param labelName - ラベル名
+ * @returns 指定したラベルの未読記事のリスト
+ */
+export async function getUnreadArticlesByLabel(labelName: string) {
+	const response = await fetch(
+		`${getApiBaseUrl()}/api/bookmarks?label=${encodeURIComponent(labelName)}`,
+	);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch unread articles for label "${labelName}": ${response.statusText}`,
+		);
+	}
+
+	const data = await response.json();
+	const parsed = ArticlesResponseSchema.safeParse(data);
+	if (!parsed.success) {
+		throw new Error(
+			`Invalid API response for unread articles by label: ${parsed.error.message}`,
+		);
+	}
+	return parsed.data.bookmarks;
+}

--- a/mcp/src/test/getUnreadArticlesByLabel.test.ts
+++ b/mcp/src/test/getUnreadArticlesByLabel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import * as apiClient from "../lib/apiClient.js";
+
+// このテストはMCPツールとAPIクライアントの統合をテストします
+describe("getUnreadArticlesByLabel", () => {
+	it("APIクライアント関数が正しくエクスポートされている", () => {
+		expect(apiClient.getUnreadArticlesByLabel).toBeDefined();
+		expect(typeof apiClient.getUnreadArticlesByLabel).toBe("function");
+	});
+
+	it("関数が正しいパラメータを受け取る", async () => {
+		// 環境変数が設定されていない場合のエラーをキャッチ
+		try {
+			await apiClient.getUnreadArticlesByLabel("test-label");
+		} catch (error) {
+			// API_BASE_URLが設定されていない場合のエラーを期待
+			expect(error).toBeInstanceOf(Error);
+			if (error instanceof Error) {
+				expect(error.message).toContain("API_BASE_URL");
+			}
+		}
+	});
+});


### PR DESCRIPTION
## 概要
MCP Serverにラベル別未読記事取得ツールを追加しました。
これにより、Claude Desktopから特定のラベルが付いた未読記事を取得できるようになります。

## 変更内容
- ラベルで未読記事を取得するAPIクライアント関数を追加
- 新しいMCPツール "getUnreadArticlesByLabel" を実装
- テストファイルを作成
- READMEを更新してツールを文書化
- バージョンを0.3.0から0.4.0に更新

## テスト計画
- [ ] ユニットテストがパスすることを確認
- [ ] Claude DesktopでMCPサーバーをビルドして新しいツールがリストされることを確認
- [ ] ツールを実行して正しくラベル別の未読記事が取得できることを確認

## Issue
closes #421

## その他
既存のAPIエンドポイント`/api/bookmarks/?label={labelName}`がすでにラベルフィルター時に未読記事のみを返すよう実装されていたため、新しいAPIエンドポイントの作成は不要でした。

🤖 Generated with [Claude Code](https://claude.ai/code)