### PR TITLE
🎨 fix: Summary部分と各種ボタンのUIの位置重なりを解消 (#416)

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -86,7 +86,7 @@ export function BookmarkCard({
 
 	return (
 		<article
-			className={`relative p-4 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
+			className={`relative p-4 pb-16 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
 				isRead ? "bg-gray-50" : ""
 			}`}
 		>
@@ -271,12 +271,14 @@ export function BookmarkCard({
 			<p className="text-xs text-gray-500">{formattedDate}</p>
 
 			{/* 要約表示 */}
-			<BookmarkSummary
-				summary={summary || null}
-				summaryUpdatedAt={summaryUpdatedAt || null}
-				isGenerating={isGeneratingSummary}
-				onGenerateSummary={handleGenerateSummary}
-			/>
+			<div className="mt-3 mb-12">
+				<BookmarkSummary
+					summary={summary || null}
+					summaryUpdatedAt={summaryUpdatedAt || null}
+					isGenerating={isGeneratingSummary}
+					onGenerateSummary={handleGenerateSummary}
+				/>
+			</div>
 		</article>
 	);
 }


### PR DESCRIPTION
## 概要
BookmarkCardコンポーネントでSummary部分と各種ボタンのUIが重なる問題を修正しました。

## 変更内容
- カードコンポーネントの下部パディングを`pb-16`に変更し、ボタン配置用のスペースを確保
- Summary部分を`mb-12`のdivでラップし、下部のボタンとの重なりを解消

## 修正内容の詳細
1. **下部パディングの調整**: 
   - 変更前: `p-4`（全方向に同じパディング）
   - 変更後: `p-4 pb-16`（下部のみ16のパディング）

2. **要約部分のマージン調整**:
   - Summary部分を`<div className="mt-3 mb-12">`でラップ
   - これにより、ボタンとの適切な間隔を確保

## 確認事項
- [x] リントチェックが通ることを確認
- [x] UIの重なりが解消されていることを確認
- [x] 既存の機能に影響がないことを確認

Closes #416

🤖 Generated with [Claude Code](https://claude.ai/code)