### PR TITLE
RSSフィード編雈・削除機能の実装

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,37 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	children: ReactNode;
+	variant?: "primary" | "secondary" | "danger";
+	size?: "sm" | "md" | "lg";
+}
+
+export function Button({
+	children,
+	variant = "primary",
+	size = "md",
+	className = "",
+	...props
+}: ButtonProps) {
+	const baseStyles = "font-medium rounded-lg transition-colors duration-200";
+
+	const variantStyles = {
+		primary: "bg-blue-500 text-white hover:bg-blue-600",
+		secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+		danger: "bg-red-500 text-white hover:bg-red-600",
+	};
+
+	const sizeStyles = {
+		sm: "px-3 py-1.5 text-sm",
+		md: "px-4 py-2 text-base",
+		lg: "px-6 py-3 text-lg",
+	};
+
+	const combinedClassName = `${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`;
+
+	return (
+		<button className={combinedClassName} {...props}>
+			{children}
+		</button>
+	);
+}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/Button";
+import { Modal } from "@/components/Modal";
+
+interface ConfirmDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	title: string;
+	message: string;
+	confirmText?: string;
+	cancelText?: string;
+	isLoading?: boolean;
+}
+
+export function ConfirmDialog({
+	isOpen,
+	onClose,
+	onConfirm,
+	title,
+	message,
+	confirmText = "削除",
+	cancelText = "キャンセル",
+	isLoading = false,
+}: ConfirmDialogProps) {
+	return (
+		<Modal isOpen={isOpen} onClose={onClose} title={title}>
+			<div className="py-3">
+				<p className="text-gray-600">{message}</p>
+			</div>
+
+			<div className="flex justify-end gap-2 pt-4">
+				<Button
+					type="button"
+					onClick={onClose}
+					variant="secondary"
+					disabled={isLoading}
+				>
+					{cancelText}
+				</Button>
+				<Button
+					type="button"
+					onClick={onConfirm}
+					variant="danger"
+					disabled={isLoading}
+				>
+					{isLoading ? "処理中..." : confirmText}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/frontend/src/features/feeds/components/CreateFeedModal.tsx
+++ b/frontend/src/features/feeds/components/CreateFeedModal.tsx
@@ -16,7 +16,7 @@ export function CreateFeedModal({ isOpen, onClose }: CreateFeedModalProps) {
 	});
 
 	const [errors, setErrors] = useState<Record<string, string>>({});
-	const { mutate: createFeed, isLoading } = useCreateRSSFeed();
+	const { mutate: createFeed, isPending } = useCreateRSSFeed();
 
 	const validateForm = (): boolean => {
 		const newErrors: Record<string, string> = {};
@@ -143,16 +143,16 @@ export function CreateFeedModal({ isOpen, onClose }: CreateFeedModalProps) {
 						type="button"
 						onClick={onClose}
 						className="px-4 py-2 text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300"
-						disabled={isLoading}
+						disabled={isPending}
 					>
 						キャンセル
 					</button>
 					<button
 						type="submit"
 						className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-						disabled={isLoading}
+						disabled={isPending}
 					>
-						{isLoading ? "登録中..." : "登録"}
+						{isPending ? "登録中..." : "登録"}
 					</button>
 				</div>
 			</form>

--- a/frontend/src/features/feeds/components/EditFeedModal.tsx
+++ b/frontend/src/features/feeds/components/EditFeedModal.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/Button";
+import { Modal } from "@/components/Modal";
+import { type FormEvent, useState } from "react";
+import { useUpdateRSSFeed } from "../queries/useRSSFeeds";
+import type { RSSFeed } from "../types";
+
+interface EditFeedModalProps {
+	feed: RSSFeed;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function EditFeedModal({ feed, isOpen, onClose }: EditFeedModalProps) {
+	const [formData, setFormData] = useState({
+		name: feed.name,
+		url: feed.url,
+		isActive: feed.isActive,
+	});
+
+	const { mutate: updateFeed, isPending } = useUpdateRSSFeed();
+
+	const handleSubmit = (e: FormEvent) => {
+		e.preventDefault();
+		updateFeed(
+			{ id: feed.id, data: formData },
+			{
+				onSuccess: () => {
+					onClose();
+				},
+			},
+		);
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={onClose} title="フィードを編集">
+			<form onSubmit={handleSubmit} className="space-y-4">
+				<div>
+					<label htmlFor="name" className="block text-sm font-medium mb-2">
+						フィード名
+					</label>
+					<input
+						type="text"
+						id="name"
+						value={formData.name}
+						onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+						placeholder="フィード名"
+						required
+						className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+
+				<div>
+					<label htmlFor="url" className="block text-sm font-medium mb-2">
+						RSS URL
+					</label>
+					<input
+						type="url"
+						id="url"
+						value={formData.url}
+						onChange={(e) => setFormData({ ...formData, url: e.target.value })}
+						placeholder="RSS URL"
+						required
+						className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+					/>
+				</div>
+
+				<div className="flex items-center">
+					<input
+						type="checkbox"
+						id="isActive"
+						checked={formData.isActive}
+						onChange={(e) =>
+							setFormData({ ...formData, isActive: e.target.checked })
+						}
+						className="mr-2"
+					/>
+					<label htmlFor="isActive" className="text-sm font-medium">
+						有効
+					</label>
+				</div>
+
+				<div className="flex justify-end gap-2 pt-4">
+					<Button
+						type="button"
+						onClick={onClose}
+						variant="secondary"
+						disabled={isPending}
+					>
+						キャンセル
+					</Button>
+					<Button type="submit" disabled={isPending}>
+						{isPending ? "更新中..." : "更新"}
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/frontend/src/features/feeds/pages/FeedListPage.tsx
+++ b/frontend/src/features/feeds/pages/FeedListPage.tsx
@@ -4,22 +4,10 @@ import { useState } from "react";
 import { CreateFeedModal } from "../components/CreateFeedModal";
 import { FeedCard } from "../components/FeedCard";
 import { useRSSFeeds } from "../queries/useRSSFeeds";
-import type { RSSFeed } from "../types";
 
 export function FeedListPage() {
 	const { data, isLoading, error } = useRSSFeeds();
 	const [isModalOpen, setIsModalOpen] = useState(false);
-
-	// 編集、削除のハンドラー（今回は未実装）
-	const handleEdit = (feed: RSSFeed) => {
-		// TODO: 編集モーダルの実装
-		console.log("Edit feed:", feed);
-	};
-
-	const handleDelete = (id: number) => {
-		// TODO: 削除機能の実装
-		console.log("Delete feed:", id);
-	};
 
 	// ローディング状態
 	if (isLoading) {
@@ -80,12 +68,7 @@ export function FeedListPage() {
 			) : (
 				<div className="grid gap-4">
 					{feeds.map((feed) => (
-						<FeedCard
-							key={feed.id}
-							feed={feed}
-							onEdit={handleEdit}
-							onDelete={handleDelete}
-						/>
+						<FeedCard key={feed.id} feed={feed} />
 					))}
 				</div>
 			)}

--- a/frontend/src/features/feeds/queries/useRSSFeeds.ts
+++ b/frontend/src/features/feeds/queries/useRSSFeeds.ts
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UpdateRSSFeedDTO } from "../types";
 import { feedsApi } from "./api";
 import { queryKeys } from "./queryKeys";
 
@@ -6,5 +7,28 @@ export const useRSSFeeds = () => {
 	return useQuery({
 		queryKey: queryKeys.list(),
 		queryFn: feedsApi.getFeeds,
+	});
+};
+
+export const useUpdateRSSFeed = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ id, data }: { id: number; data: UpdateRSSFeedDTO }) =>
+			feedsApi.updateFeed(id, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.list() });
+		},
+	});
+};
+
+export const useDeleteRSSFeed = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (id: number) => feedsApi.deleteFeed(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.list() });
+		},
 	});
 };


### PR DESCRIPTION
## Summary
• RSSフィードの編雈機能を実装
• RSSフィードの削除機能を実装
• 便利なコンポーネント（Button, ConfirmDialog, EditFeedModal）を作成

## Changes
- `Button`コンポーネントを作成
- `ConfirmDialog`コンポーネントを作成  
- `EditFeedModal`コンポーネントを作成
- `useUpdateRSSFeed`と`useDeleteRSSFeed`フックを実装
- `FeedCard`コンポーネントに編集・削除ボタンを追加
- React Queryのバージョン対応（isLoading → isPending）

## Issue
Closes #384 

## Test plan
- [ ] RSSフィード一覧で編集ボタンをクリックすると編集モーダルが開く
- [ ] 編集モーダルでフィード名、URL、有効ステータスを変更できる
- [ ] 編集後、一覧に反映される
- [ ] RSSフィード一覧で削除ボタンをクリックすると確認ダイアログが表示される
- [ ] 確認ダイアログで削除を実行するとフィードが削除される
- [ ] 削除後、一覧から消える

🤖 Generated with [Claude Code](https://claude.ai/code)