### PR TITLE
✨ スマホ表示時のヘッダーメニューをハンバーガーメニューに変更

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,15 +2,29 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 
 export function Header() {
 	const pathname = usePathname();
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
 
 	const isActive = (path: string) => {
 		return pathname === path
 			? "text-blue-600 border-b-2 border-blue-600"
 			: "text-gray-600 hover:text-blue-500";
 	};
+
+	const toggleMenu = () => {
+		setIsMenuOpen(!isMenuOpen);
+	};
+
+	const menuItems = [
+		{ href: "/", label: "未読一覧" },
+		{ href: "/favorites", label: "お気に入り" },
+		{ href: "/recent", label: "最近読んだ記事" },
+		{ href: "/labels", label: "ラベル設定" },
+		{ href: "/feeds", label: "RSS管理" },
+	];
 
 	return (
 		<header className="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
@@ -22,39 +36,85 @@ export function Header() {
 						</Link>
 					</div>
 
-					<nav className="flex space-x-8">
-						<Link
-							href="/"
-							className={`inline-flex items-center px-1 pt-1 ${isActive("/")}`}
-						>
-							未読一覧
-						</Link>
-						<Link
-							href="/favorites"
-							className={`inline-flex items-center px-1 pt-1 ${isActive("/favorites")}`}
-						>
-							お気に入り
-						</Link>
-						<Link
-							href="/recent"
-							className={`inline-flex items-center px-1 pt-1 ${isActive("/recent")}`}
-						>
-							最近読んだ記事
-						</Link>
-						<Link
-							href="/labels"
-							className={`inline-flex items-center px-1 pt-1 ${isActive("/labels")}`}
-						>
-							ラベル設定
-						</Link>
-						<Link
-							href="/feeds"
-							className={`inline-flex items-center px-1 pt-1 ${isActive("/feeds")}`}
-						>
-							RSS管理
-						</Link>
+					{/* デスクトップ用メニュー */}
+					<nav className="hidden md:flex space-x-8">
+						{menuItems.map((item) => (
+							<Link
+								key={item.href}
+								href={item.href}
+								className={`inline-flex items-center px-1 pt-1 ${isActive(item.href)}`}
+							>
+								{item.label}
+							</Link>
+						))}
 					</nav>
+
+					{/* モバイル用ハンバーガーメニューボタン */}
+					<div className="md:hidden">
+						<button
+							type="button"
+							onClick={toggleMenu}
+							className="inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-800 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+						>
+							<span className="sr-only">メニューを開く</span>
+							{isMenuOpen ? (
+								<svg
+									className="block h-6 w-6"
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth={2}
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							) : (
+								<svg
+									className="block h-6 w-6"
+									xmlns="http://www.w3.org/2000/svg"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth={2}
+										d="M4 6h16M4 12h16M4 18h16"
+									/>
+								</svg>
+							)}
+						</button>
+					</div>
 				</div>
+
+				{/* モバイル用ドロップダウンメニュー */}
+				{isMenuOpen && (
+					<div className="md:hidden">
+						<div className="px-2 pt-2 pb-3 space-y-1">
+							{menuItems.map((item) => (
+								<Link
+									key={item.href}
+									href={item.href}
+									className={`block px-3 py-2 rounded-md text-base font-medium ${
+										pathname === item.href
+											? "text-blue-600 bg-blue-50"
+											: "text-gray-700 hover:text-gray-900 hover:bg-gray-50"
+									}`}
+									onClick={() => setIsMenuOpen(false)}
+								>
+									{item.label}
+								</Link>
+							))}
+						</div>
+					</div>
+				)}
 			</div>
 		</header>
 	);


### PR DESCRIPTION
## 概要
モバイル表示時のヘッダーメニューをハンバーガーメニューに変更しました。

Closes #441

## 変更内容
- モバイル画面でのヘッダーメニューをハンバーガーメニューに変更
- メニュー項目の増加による視認性低下を改善
- デスクトップ表示は現状のレイアウトを維持
- モバイル用のドロップダウンメニューを実装

## テスト方法
1. フロントエンドの開発サーバーを起動（`cd frontend && npm run dev`）
2. ブラウザのデベロッパーツールでモバイル表示にする
3. ヘッダーのハンバーガーメニューが表示される
4. メニューをクリックすると、各ページへのリンクが表示される
5. リンクをクリックするとページに遷移し、メニューが閉じる

## スクリーンショット
### モバイル表示
- ハンバーガーメニューが表示される
- メニューを開くとドロップダウンで各ページへのリンクが表示される

### デスクトップ表示
- 従来通りの表示を維持

## レビューポイント
- レスポンシブ対応の実装方法
- メニューの開閉処理
- アクセシビリティ対応（sr-only、aria-hidden）