### PR TITLE
✨ feat: Dependabotの設定改善 - vitestパッケージの依存関係をグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,8 +63,12 @@ updates:
         patterns:
           # テスト関連パッケージ
           - "vitest"
-          - "@vitest/coverage-v8"
+          - "@vitest/*"
           - "happy-dom"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       code-quality:
         patterns:
           # コード品質管理ツール
@@ -104,6 +108,15 @@ updates:
           - "@modelcontextprotocol/sdk"
           - "zod"
           - "typescript"
+      vitest-ecosystem:
+        patterns:
+          # vitestとその関連パッケージ
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       dev-tools:
         patterns:
           # 開発ツール関連

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **エラー処理**: try/catchブロックで明示的にエラーを処理
 - **テスト記述**: テスト内容は日本語で記述し、理解しやすくする
 
+## 依存関係管理
+- **Dependabot**: `.github/dependabot.yml`で設定
+  - 各ディレクトリごと（api, frontend, extension, mcp）に個別に依存関係を管理
+  - 依存パッケージはグループ化されており、関連パッケージは一括で更新される
+  - テスト関連パッケージ（vitest, @vitest/*）は同時に更新する必要があるためグループ化
+
 ## 言語設定
 - 日本語での解答生成を優先する
 - コードコメントは日本語で書く


### PR DESCRIPTION
## 概要
Issue #456 の対応として、Dependabotの設定を改善し、vitestとその関連パッケージを同じグループで更新するよう設定しました。

## 変更内容
- MCPディレクトリに  グループを追加
  -  と  パターンを含め、関連パッケージを同時に更新
  -  を設定し、major/minor/patch全ての更新を対象に
- APIディレクトリの  グループの設定を改善
  -  から  に変更してより広くカバー
  -  を追加してバージョン更新範囲を明示
- CLAUDE.mdに依存関係管理に関する情報を追加

## 背景・理由
PR #454（@vitest/coverage-v8の更新）とPR #451（vitestの更新）のようなケースで、相互に依存関係があるパッケージが個別に更新されるとCIが失敗していました。これらのパッケージを同時に更新することで、依存関係の競合を防ぎます。

## 検証方法
- YAMLの構文チェックを実施済み
- Dependabotの設定に基づいた更新は次回のスケジュール実行時に確認

Closes #456