### PR TITLE
✨ feat: 既読一覧では要約の表示を非表示に対応

### DIFF
--- a/frontend/src/app/recent/page.tsx
+++ b/frontend/src/app/recent/page.tsx
@@ -94,7 +94,11 @@ export default function RecentPage() {
 						</h2>
 						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 							{groupedBookmarks[date].map((bookmark) => (
-								<BookmarkCard key={bookmark.id} bookmark={bookmark} />
+								<BookmarkCard
+									key={bookmark.id}
+									bookmark={bookmark}
+									showSummary={false}
+								/>
 							))}
 						</div>
 					</div>

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -10,9 +10,14 @@ import { BookmarkSummary } from "./BookmarkSummary";
 interface Props {
 	bookmark: BookmarkWithLabel;
 	onLabelClick?: (labelName: string) => void;
+	showSummary?: boolean;
 }
 
-export function BookmarkCard({ bookmark, onLabelClick }: Props) {
+export function BookmarkCard({
+	bookmark,
+	onLabelClick,
+	showSummary = true,
+}: Props) {
 	const {
 		id,
 		title,
@@ -310,13 +315,16 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 			</p>
 			<p className="text-xs text-gray-500">{formattedDate}</p>
 
-			{/* 要約表示 */}
-			<div className="mt-3 mb-12">
-				<BookmarkSummary
-					summary={summary || null}
-					summaryUpdatedAt={summaryUpdatedAt || null}
-				/>
-			</div>
+			{/* 要約表示 - 条件付きレンダリング */}
+			{showSummary && (
+				<div className="mt-3 mb-12">
+					<BookmarkSummary
+						summary={summary || null}
+						summaryUpdatedAt={summaryUpdatedAt || null}
+					/>
+				</div>
+			)}
+			{!showSummary && <div className="mb-12" />}
 		</article>
 	);
 }


### PR DESCRIPTION
## Summary
- BookmarkCardコンポーネントを拡張し、要約の表示・非表示を制御できるようにしました
- 既読一覧ページ（RecentPage）では要約を非表示に設定し、UIをシンプルにしました

## Test plan
- 既読一覧ページで記事カードに要約が表示されていないことを確認
- 他のページでは以前と同様に要約が表示されることを確認

Closes #464

🤖 Generated with [Claude Code](https://claude.ai/code)