### PR TITLE
🐛 fix: getBookmarkWithoutSummryのMCPが正常に利用できない問題を修正

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -362,6 +362,44 @@ server.tool(
 	},
 );
 
+// 9.1 Compatibility tool for typo in "getBookmarkWithoutSummry"
+server.tool(
+	"getBookmarkWithoutSummry", // Intentional typo for backward compatibility
+	{
+		limit: z.number().int().positive().optional(),
+		orderBy: z.enum(["createdAt", "readAt"]).optional(),
+	},
+	async ({ limit, orderBy }) => {
+		try {
+			// Forward to the correctly named function
+			const bookmarks = await apiClient.getBookmarksWithoutSummary(
+				limit,
+				orderBy,
+			);
+			return {
+				content: [{ type: "text", text: JSON.stringify(bookmarks, null, 2) }],
+				isError: false,
+			};
+		} catch (error: unknown) {
+			const errorMessage =
+				error instanceof Error ? error.message : String(error);
+			console.error(
+				`Error in getBookmarkWithoutSummry tool (typo-compatibility) (limit: ${limit}, orderBy: ${orderBy}):`,
+				errorMessage,
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Failed to get bookmarks without summary: ${errorMessage}`,
+					},
+				],
+				isError: true,
+			};
+		}
+	},
+);
+
 // 10. Tool to save summary
 server.tool(
 	"saveSummary",


### PR DESCRIPTION
## 概要
- MCPの関数名が誤って呼び出されている問題を修正しました（`getBookmarkWithoutSummry`）
- 誤った関数名（`getBookmarkWithoutSummry`）でも動作するよう、互換性のある関数を追加しました
- 正しい関数名（`getBookmarksWithoutSummary`）へ転送する仕組みを実装しました

## テスト項目
- [x] MCP関数が正常に動作することを確認
- [x] 既存のテストが失敗しないことを確認
- [x] lintとtypecheckが成功することを確認

close #444

🤖 Generated with [Claude Code](https://claude.ai/code)