### PR TITLE
✨ feat: 未読一覧画面_要約ボタンの位置を変更 #480

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -102,9 +102,45 @@ export function BookmarkCard({
 				isRead ? "bg-gray-50" : ""
 			}`}
 		>
-			{/* ラベル表示 */}
+			{/* 要約ボタン - 一番左に配置 */}
+			<button
+				type="button"
+				onClick={handleToggleSummary}
+				disabled={!summary}
+				className={`absolute bottom-2 left-2 z-10 p-1 rounded-full transition-colors ${
+					!summary
+						? "text-gray-400 bg-gray-100 cursor-not-allowed"
+						: showSummaryContent
+							? "text-blue-700 bg-blue-50 hover:bg-blue-100"
+							: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
+				}`}
+				title={
+					!summary
+						? "要約がありません"
+						: showSummaryContent
+							? "要約を閉じる"
+							: "要約を表示"
+				}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					strokeWidth={1.5}
+					stroke="currentColor"
+					className="w-6 h-6"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+					/>
+				</svg>
+			</button>
+
+			{/* ラベル表示 - 要約ボタンの右に配置 */}
 			{label && (
-				<div className="absolute bottom-2 left-2 z-10">
+				<div className="absolute bottom-2 left-12 z-10">
 					<LabelDisplay label={label} onClick={onLabelClick} />
 				</div>
 			)}
@@ -381,41 +417,15 @@ export function BookmarkCard({
 			</p>
 			<p className="text-xs text-gray-500">{formattedDate}</p>
 
-			{/* 要約ボタン */}
-			<div className="mt-3 mb-3">
-				<button
-					type="button"
-					onClick={handleToggleSummary}
-					disabled={!summary}
-					className={`px-3 py-1 text-sm rounded border transition-colors ${
-						!summary
-							? "text-gray-400 border-gray-300 bg-gray-100 cursor-not-allowed"
-							: showSummaryContent
-								? "text-blue-700 border-blue-300 bg-blue-50 hover:bg-blue-100"
-								: "text-gray-700 border-gray-300 bg-white hover:bg-gray-50"
-					}`}
-					title={
-						!summary
-							? "要約がありません"
-							: showSummaryContent
-								? "要約を閉じる"
-								: "要約を表示"
-					}
-				>
-					要約
-				</button>
-			</div>
-
-			{/* 要約表示 - 条件付きレンダリング */}
+			{/* 要約表示 - アイコンの下に配置 */}
 			{showSummaryContent && summary && (
-				<div className="mb-12">
+				<div className="mt-12">
 					<BookmarkSummary
 						summary={summary || null}
 						summaryUpdatedAt={summaryUpdatedAt || null}
 					/>
 				</div>
 			)}
-			{!showSummaryContent && <div className="mb-12" />}
 		</article>
 	);
 }


### PR DESCRIPTION
## Summary
- 要約ボタンを日付の下からアイコン行の一番左側に移動
- ボタンをテキスト形式からアイコン形式に変更  
- 要約内容の表示位置をアイコンの下に配置

## Issue
Closes #480

## 変更内容
### BookmarkCardコンポーネント
- 要約ボタンをアイコン形式に変更し、既存アイコン群の一番左に配置
- ラベル表示位置を要約ボタンの右側（left-12）に調整
- 要約内容をアイコン行の下に表示するよう変更（mt-12）
- 古いテキスト形式の要約ボタンを削除

## 動作確認
- [ ] 要約ボタンがアイコン行の一番左に表示されること
- [ ] 要約がある記事では要約ボタンがクリック可能なこと
- [ ] 要約がない記事では要約ボタンがグレーアウトされること
- [ ] 要約内容がアイコンの下に表示されること
- [ ] 既存の他のアイコンが正常に動作すること

## スクリーンショット
実装前後の比較

### Before
要約ボタンが日付の下にテキスト形式で表示

### After  
要約ボタンがアイコン行の一番左にアイコン形式で表示

🤖 Generated with [Claude Code](https://claude.ai/code)