### PR TITLE
✨ feat: MCPツールでClaude Desktopが記事URLに直接アクセスする機能の実装 #486

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -21,7 +21,9 @@ This directory contains the MCP (Model Context Protocol) server that provides to
 - **`saveSummary`**: 生成した要約をブックマークに保存します。（引数: `bookmarkId`, `summary`）
 - **`updateSummary`**: 既存の要約を更新します。（引数: `bookmarkId`, `summary`）
 - **`getBookmarkById`**: 特定のブックマークを取得します。（引数: `bookmarkId`）
-- **`generateSummary`**: ブックマークの要約を生成します（現在は仮実装）。（引数: `bookmarkId`, `includeKeyPoints`, `maxLength`）
+- **`generateSummary`**: Claude Desktopに記事URLへのアクセスと要約生成を指示します。（引数: `bookmarkId`, `includeKeyPoints`, `maxLength`）
+  - Claude Desktopが記事にアクセスし、エンジニア向けの要約を生成
+  - 技術的な学習ポイントを抽出する形式で要約
 - **`getUnreadArticlesByLabel`**: 指定されたラベルの未読記事を取得します。（引数: `labelName`）
 
 ## Connecting with a Client

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -517,6 +517,7 @@ server.tool(
 );
 
 // 13. Tool to generate summary for a bookmark
+// このツールはClaude Desktopに記事アクセスと要約生成の指示を返す
 server.tool(
 	"generateSummary",
 	{
@@ -542,47 +543,56 @@ server.tool(
 				};
 			}
 
-			// URLから記事内容を取得（実際の実装では記事本文を取得する）
-			// ここは仮実装として、タイトルとURLを使用
-			const summaryPrompt = `
-以下の記事を要約してください:
-タイトル: ${bookmark.title || "タイトルなし"}
+			// Claude Desktopに記事内容の取得と要約生成を依頼
+			// このツールはClaude Desktopに指示を返し、Claude Desktop側で記事にアクセスして要約を生成する
+			const instructionForClaude = `
+以下のURLの技術記事を読み込んで、エンジニア向けの要約を生成してください。
+
 URL: ${bookmark.url}
+タイトル: ${bookmark.title || "タイトルなし"}
+ブックマークID: ${bookmarkId}
 
-要約条件:
-- 最大${maxLength}文字で簡潔に
-${includeKeyPoints ? "- 主要なポイントを箇条書きで含める" : ""}
-- 日本語で記述
-- 技術記事として重要な情報を優先
-`;
+要約の要件:
+1. 日本語で${maxLength}文字以内で作成
+2. 以下の形式で構成:
+   【概要】
+   記事の主旨を1-2文で説明
+   
+   ${
+			includeKeyPoints
+				? `【学習ポイント】
+   ・技術的に重要な概念やパターン
+   ・新しく学べる技術やツール
+   ・ベストプラクティスや注意点
+   
+   【実装に役立つ情報】
+   ・具体的なコード例やコマンド
+   ・設定方法や使用手順
+   ・パフォーマンスやセキュリティの考慮点
+   
+   【関連技術】
+   記事で言及されている関連技術やライブラリ`
+				: "記事の技術的な内容を簡潔にまとめる"
+		}
 
-			// ここで実際にはLLMを呼び出して要約を生成
-			// 現時点では仮の要約を生成
-			const mockSummary = `この記事は「${bookmark.title || "untitled"}」に関する内容です。
-${
-	includeKeyPoints
-		? `
-主要なポイント:
-• 技術的な概要
-• 実装のアプローチ
-• 利用されている技術スタック
-• まとめと結論`
-		: ""
-}
+3. エンジニアが後で見返した時に、記事の価値と学習内容がすぐ分かるようにする
+4. 専門用語は適切に使用し、技術的な正確性を保つ
 
-詳細な内容は元記事をご確認ください。`;
+手順:
+1. 上記URLにアクセスして記事内容を読み込む
+2. 技術的な観点から要約を生成
+3. 生成した要約を saveSummary ツールを使って保存する (bookmarkId: ${bookmarkId})
 
-			// 要約を保存
-			const updatedBookmark = await apiClient.saveSummary(
-				bookmarkId,
-				mockSummary,
-			);
+注意: 
+- 記事にアクセスできない場合は、その旨を明記してください
+- ペイウォールや認証が必要な場合も、アクセスできない理由を説明してください
+- 要約生成後は必ず saveSummary ツールで保存してください`;
 
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Successfully generated and saved summary for bookmark ${bookmarkId}:\n${JSON.stringify(updatedBookmark, null, 2)}`,
+						text: instructionForClaude,
 					},
 				],
 				isError: false,


### PR DESCRIPTION
## Summary
- MCPのgenerateSummaryツールを更新し、Claude Desktopが記事URLに直接アクセスして要約を生成する仕組みを実装
- エンジニア向けの要約フォーマットを定義（学習ポイント、実装情報、関連技術）

## 変更内容

### 1. generateSummaryツールの更新
- モック実装からClaude Desktopへの指示を返す実装に変更
- Claude Desktopが記事にアクセスし、技術的な観点から要約を生成
- 生成した要約をsaveSummaryツールで保存する流れ

### 2. エンジニア向け要約フォーマット
```
【概要】
記事の主旨を1-2文で説明

【学習ポイント】
・技術的に重要な概念やパターン
・新しく学べる技術やツール
・ベストプラクティスや注意点

【実装に役立つ情報】
・具体的なコード例やコマンド
・設定方法や使用手順
・パフォーマンスやセキュリティの考慮点

【関連技術】
記事で言及されている関連技術やライブラリ
```

### 3. エラーハンドリング
- 記事にアクセスできない場合の対応
- ペイウォールや認証が必要な場合の説明

## Test plan
- [x] generateSummaryのテストを新しい仕様に合わせて更新
- [x] テストが全て通ることを確認
- [x] リント・タイプチェックが通ることを確認
- [ ] Claude Desktopで実際に動作確認

## 関連Issue
- #483 MCP＞要約生成機能 UXが悪い
- #486 MCPツールでClaude Desktopが記事URLに直接アクセスする機能の実装

🤖 Generated with [Claude Code](https://claude.ai/code)