### PR TITLE
🐛 fix: RSS バッチ処理でのFOREIGN KEY制約エラーを修正 #498

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -103,9 +103,7 @@ export const rssFeedItems = sqliteTable("rss_feed_items", {
 // RSSバッチログ
 export const rssBatchLogs = sqliteTable("rss_batch_logs", {
 	id: integer("id").primaryKey({ autoIncrement: true }),
-	feedId: integer("feed_id")
-		.notNull()
-		.references(() => rssFeeds.id),
+	feedId: integer("feed_id").references(() => rssFeeds.id),
 	status: text("status").notNull(),
 	itemsFetched: integer("items_fetched").notNull().default(0),
 	itemsCreated: integer("items_created").notNull().default(0),

--- a/api/src/services/batchProcessor.ts
+++ b/api/src/services/batchProcessor.ts
@@ -52,7 +52,7 @@ export class RSSBatchProcessor {
 				.values({
 					status: "in_progress",
 					startedAt: new Date(),
-					feedId: 1, // 暫定的に1を使用（後でスキーマ変更が必要）
+					feedId: null, // バッチ全体のログはfeedId不要
 					itemsCreated: 0,
 					itemsFetched: 0,
 				})
@@ -109,7 +109,7 @@ export class RSSBatchProcessor {
 				errorMessage,
 				startedAt: new Date(),
 				finishedAt: new Date(),
-				feedId: 0, // バッチ全体のログなのでfeedIdは0とする
+				feedId: null, // バッチ全体のログはfeedId不要
 				itemsCreated: 0,
 				itemsFetched: 0,
 			});


### PR DESCRIPTION
## Summary
- rssBatchLogsテーブルのfeedIdをNULL許可に変更
- CloudflareでのCRONバッチ処理のFOREIGN KEY制約エラーを解決

## Test plan
- [x] 既存のテストが正常に通過することを確認
- [x] スキーマ変更によりfeedIdがNULL許可になることを確認
- [x] バッチログ処理でfeedId: nullが使用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)