### PR TITLE
feat: フロントエンドテストカバレッジを大幅改善（2.05% → 36.68%）

### DIFF
--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+	test("ダイアログが開いている時に表示される", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={true}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+			/>,
+		);
+
+		expect(screen.getByText("確認ダイアログ")).toBeInTheDocument();
+		expect(screen.getByText("本当に削除しますか？")).toBeInTheDocument();
+		expect(screen.getByText("削除")).toBeInTheDocument();
+		expect(screen.getByText("キャンセル")).toBeInTheDocument();
+	});
+
+	test("ダイアログが閉じている時は表示されない", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={false}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+			/>,
+		);
+
+		expect(screen.queryByText("確認ダイアログ")).not.toBeInTheDocument();
+		expect(screen.queryByText("本当に削除しますか？")).not.toBeInTheDocument();
+	});
+
+	test("確認ボタンクリックでonConfirmが呼ばれる", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={true}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+			/>,
+		);
+
+		const confirmButton = screen.getByText("削除");
+		fireEvent.click(confirmButton);
+
+		expect(mockOnConfirm).toHaveBeenCalled();
+	});
+
+	test("キャンセルボタンクリックでonCloseが呼ばれる", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={true}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+			/>,
+		);
+
+		const cancelButton = screen.getByText("キャンセル");
+		fireEvent.click(cancelButton);
+
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+
+	test("カスタムボタンテキストが表示される", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={true}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+				confirmText="実行"
+				cancelText="やめる"
+			/>,
+		);
+
+		expect(screen.getByText("実行")).toBeInTheDocument();
+		expect(screen.getByText("やめる")).toBeInTheDocument();
+	});
+
+	test("ローディング中は確認ボタンが無効化される", () => {
+		const mockOnClose = vi.fn();
+		const mockOnConfirm = vi.fn();
+
+		render(
+			<ConfirmDialog
+				isOpen={true}
+				onClose={mockOnClose}
+				onConfirm={mockOnConfirm}
+				title="確認ダイアログ"
+				message="本当に削除しますか？"
+				isLoading={true}
+			/>,
+		);
+
+		const confirmButton = screen.getByText("処理中...");
+		expect(confirmButton).toBeDisabled();
+	});
+});

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import { describe, expect, test, vi } from "vitest";
+import { Header } from "./Header";
+
+// Next.jsのナビゲーションをモック
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: vi.fn(() => ({
+		push: vi.fn(),
+		refresh: vi.fn(),
+	})),
+}));
+
+describe("Header", () => {
+	test("ヘッダーが正しく表示される", () => {
+		vi.mocked(usePathname).mockReturnValue("/");
+
+		render(<Header />);
+
+		expect(screen.getByText("Yomimono")).toBeInTheDocument();
+		expect(screen.getByText("未読一覧")).toBeInTheDocument();
+		expect(screen.getByText("お気に入り")).toBeInTheDocument();
+		expect(screen.getByText("最近読んだ記事")).toBeInTheDocument();
+		expect(screen.getByText("RSS管理")).toBeInTheDocument();
+		expect(screen.getByText("ラベル設定")).toBeInTheDocument();
+	});
+
+	test("現在のページが正しくアクティブになる", () => {
+		vi.mocked(usePathname).mockReturnValue("/favorites");
+
+		render(<Header />);
+
+		const favoriteLink = screen.getByText("お気に入り").closest("a");
+		expect(favoriteLink).toHaveClass(
+			"text-blue-600",
+			"border-b-2",
+			"border-blue-600",
+		);
+	});
+
+	test("非アクティブなリンクは異なるスタイルを持つ", () => {
+		vi.mocked(usePathname).mockReturnValue("/");
+
+		render(<Header />);
+
+		const favoriteLink = screen.getByText("お気に入り").closest("a");
+		expect(favoriteLink).toHaveClass("text-gray-600", "hover:text-blue-500");
+		expect(favoriteLink).not.toHaveClass(
+			"text-blue-600",
+			"border-b-2",
+			"border-blue-600",
+		);
+	});
+
+	test("メニューボタンでモバイルメニューを切り替えできる", () => {
+		vi.mocked(usePathname).mockReturnValue("/");
+
+		render(<Header />);
+
+		const menuButton = screen.getByRole("button");
+		expect(menuButton).toBeInTheDocument();
+
+		// メニューが最初は非表示（条件付きレンダリングで存在しない）
+		expect(screen.queryByText("未読一覧")).toBeInTheDocument(); // デスクトップメニューには存在
+
+		// モバイルメニューのリンクは最初は表示されていない（条件付きレンダリング）
+		const mobileMenuItems = screen.queryAllByText("未読一覧");
+		expect(mobileMenuItems).toHaveLength(1); // デスクトップメニューのみ
+
+		// メニューボタンをクリック
+		fireEvent.click(menuButton);
+
+		// モバイルメニューが表示される（2つめの「未読一覧」が追加される）
+		const mobileMenuItemsAfterClick = screen.getAllByText("未読一覧");
+		expect(mobileMenuItemsAfterClick).toHaveLength(2); // デスクトップとモバイル
+
+		// もう一度クリックして非表示
+		fireEvent.click(menuButton);
+		const mobileMenuItemsAfterSecondClick = screen.queryAllByText("未読一覧");
+		expect(mobileMenuItemsAfterSecondClick).toHaveLength(1); // デスクトップのみ
+	});
+
+	test("すべてのナビゲーションリンクが正しいパスを持つ", () => {
+		vi.mocked(usePathname).mockReturnValue("/");
+
+		render(<Header />);
+
+		expect(screen.getByText("未読一覧").closest("a")).toHaveAttribute(
+			"href",
+			"/",
+		);
+		expect(screen.getByText("お気に入り").closest("a")).toHaveAttribute(
+			"href",
+			"/favorites",
+		);
+		expect(screen.getByText("最近読んだ記事").closest("a")).toHaveAttribute(
+			"href",
+			"/recent",
+		);
+		expect(screen.getByText("RSS管理").closest("a")).toHaveAttribute(
+			"href",
+			"/feeds",
+		);
+		expect(screen.getByText("ラベル設定").closest("a")).toHaveAttribute(
+			"href",
+			"/labels",
+		);
+	});
+});

--- a/frontend/src/components/Modal.test.tsx
+++ b/frontend/src/components/Modal.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { Modal } from "./Modal";
+
+describe("Modal", () => {
+	test("モーダルが開いている時に表示される", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		expect(screen.getByText("テストモーダル")).toBeInTheDocument();
+		expect(screen.getByText("モーダルコンテンツ")).toBeInTheDocument();
+	});
+
+	test("モーダルが閉じている時は表示されない", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={false} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		expect(screen.queryByText("テストモーダル")).not.toBeInTheDocument();
+		expect(screen.queryByText("モーダルコンテンツ")).not.toBeInTheDocument();
+	});
+
+	test("閉じるボタンクリックでonCloseが呼ばれる", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		const closeButton = screen.getByLabelText("閉じる");
+		fireEvent.click(closeButton);
+
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+
+	test("オーバーレイクリックでonCloseが呼ばれる", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		const overlay = screen.getByLabelText("モーダルを閉じる");
+		fireEvent.click(overlay);
+
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+
+	test("モーダルコンテンツ内クリックではonCloseが呼ばれない", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		const content = screen.getByText("モーダルコンテンツ");
+		fireEvent.click(content);
+
+		expect(mockOnClose).not.toHaveBeenCalled();
+	});
+
+	test("Escapeキー押下でonCloseが呼ばれる", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+
+	test("Escape以外のキー押下ではonCloseが呼ばれない", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		fireEvent.keyDown(document, { key: "Enter" });
+
+		expect(mockOnClose).not.toHaveBeenCalled();
+	});
+
+	test("適切なアクセシビリティ属性が設定される", () => {
+		const mockOnClose = vi.fn();
+
+		render(
+			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
+				<p>モーダルコンテンツ</p>
+			</Modal>,
+		);
+
+		const closeButton = screen.getByLabelText("閉じる");
+		expect(closeButton).toBeInTheDocument();
+
+		const overlayButton = screen.getByLabelText("モーダルを閉じる");
+		expect(overlayButton).toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/bookmarks/components/BookmarkSummary.test.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkSummary.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { BookmarkSummary } from "./BookmarkSummary";
+
+describe("BookmarkSummary", () => {
+	beforeEach(() => {
+		// モックナビゲーターの初期化
+		Object.assign(navigator, {
+			clipboard: {
+				writeText: vi.fn().mockResolvedValue(undefined),
+			},
+		});
+	});
+
+	test("要約がない場合に適切なメッセージを表示する", () => {
+		render(<BookmarkSummary summary={null} summaryUpdatedAt={null} />);
+		expect(screen.getByText("要約がありません")).toBeInTheDocument();
+	});
+
+	test("要約がある場合にタイトルと内容を表示する", () => {
+		const summary = "これはテスト要約です";
+		const summaryUpdatedAt = "2024-01-01T00:00:00Z";
+
+		render(
+			<BookmarkSummary summary={summary} summaryUpdatedAt={summaryUpdatedAt} />,
+		);
+
+		expect(screen.getByText("要約")).toBeInTheDocument();
+		expect(screen.getByText(summary)).toBeInTheDocument();
+		expect(screen.getByText("2024/1/1")).toBeInTheDocument();
+	});
+
+	test("コピーボタンをクリックしてクリップボードにコピーできる", async () => {
+		const summary = "コピーするテキスト";
+		const writeTextMock = vi.fn().mockResolvedValue(undefined);
+		Object.assign(navigator, {
+			clipboard: { writeText: writeTextMock },
+		});
+
+		render(<BookmarkSummary summary={summary} summaryUpdatedAt={null} />);
+
+		const copyButton = screen.getByText("コピー");
+		fireEvent.click(copyButton);
+
+		expect(writeTextMock).toHaveBeenCalledWith(summary);
+		await waitFor(() => {
+			expect(screen.getByText("コピー済み")).toBeInTheDocument();
+		});
+	});
+
+	test("コピー失敗時にエラーログが出力される", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const writeTextMock = vi.fn().mockRejectedValue(new Error("コピー失敗"));
+		Object.assign(navigator, {
+			clipboard: { writeText: writeTextMock },
+		});
+
+		render(<BookmarkSummary summary="テスト" summaryUpdatedAt={null} />);
+
+		const copyButton = screen.getByText("コピー");
+		fireEvent.click(copyButton);
+
+		await waitFor(() => {
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to copy summary:",
+				expect.any(Error),
+			);
+		});
+
+		consoleSpy.mockRestore();
+	});
+
+	test("展開ボタンで要約の表示/非表示を切り替えできる", () => {
+		render(<BookmarkSummary summary="テスト要約" summaryUpdatedAt={null} />);
+
+		const expandButton = screen.getByText("展開");
+		fireEvent.click(expandButton);
+
+		expect(screen.getByText("折りたたむ")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByText("折りたたむ"));
+		expect(screen.getByText("展開")).toBeInTheDocument();
+	});
+
+	test("複数行の要約を正しく表示する", () => {
+		const multilineSummary = "一行目\n二行目\n• 箇条書き";
+
+		render(
+			<BookmarkSummary summary={multilineSummary} summaryUpdatedAt={null} />,
+		);
+
+		expect(screen.getByText("一行目")).toBeInTheDocument();
+		expect(screen.getByText("二行目")).toBeInTheDocument();
+		expect(screen.getByText("• 箇条書き")).toBeInTheDocument();
+	});
+
+	test("summaryUpdatedAtがない場合は日付を表示しない", () => {
+		render(<BookmarkSummary summary="要約" summaryUpdatedAt={null} />);
+
+		expect(
+			screen.queryByText(/\d{4}\/\d{1,2}\/\d{1,2}/),
+		).not.toBeInTheDocument();
+	});
+
+	test("箇条書きの項目にはマージンが適用される", () => {
+		const summaryWithBullet = "• 箇条書き項目";
+
+		render(
+			<BookmarkSummary summary={summaryWithBullet} summaryUpdatedAt={null} />,
+		);
+
+		const bulletItem = screen.getByText("• 箇条書き項目");
+		expect(bulletItem).toHaveClass("ml-4");
+	});
+});

--- a/frontend/src/features/bookmarks/components/BookmarksList.test.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarksList.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { BookmarksList } from "./BookmarksList";
+
+const createTestQueryClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+			mutations: {
+				retry: false,
+			},
+		},
+	});
+
+const mockBookmark = {
+	id: 1,
+	url: "https://example.com",
+	title: "Test Bookmark",
+	isRead: false,
+	isFavorite: false,
+	summary: null,
+	summaryCreatedAt: null,
+	summaryUpdatedAt: null,
+	createdAt: "2024-01-01T00:00:00Z",
+	updatedAt: "2024-01-01T00:00:00Z",
+	label: {
+		id: 1,
+		name: "テスト",
+		color: "blue",
+	},
+};
+
+describe("BookmarksList", () => {
+	test("ブックマークがない場合にメッセージを表示する", () => {
+		const queryClient = createTestQueryClient();
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={[]} />
+			</QueryClientProvider>,
+		);
+		expect(
+			screen.getByText("表示するブックマークはありません。"),
+		).toBeInTheDocument();
+	});
+
+	test("ブックマークがある場合にBookmarkCardを表示する", () => {
+		const queryClient = createTestQueryClient();
+		const bookmarks = [mockBookmark];
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={bookmarks} />
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByTestId("bookmark-item")).toBeInTheDocument();
+		expect(screen.getByText("Test Bookmark")).toBeInTheDocument();
+	});
+
+	test("複数のブックマークを表示する", () => {
+		const queryClient = createTestQueryClient();
+		const bookmarks = [
+			{ ...mockBookmark, id: 1, title: "First Bookmark" },
+			{ ...mockBookmark, id: 2, title: "Second Bookmark" },
+			{ ...mockBookmark, id: 3, title: "Third Bookmark" },
+		];
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={bookmarks} />
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getAllByTestId("bookmark-item")).toHaveLength(3);
+		expect(screen.getByText("First Bookmark")).toBeInTheDocument();
+		expect(screen.getByText("Second Bookmark")).toBeInTheDocument();
+		expect(screen.getByText("Third Bookmark")).toBeInTheDocument();
+	});
+
+	test("onLabelClickが提供された場合にBookmarkCardに渡される", () => {
+		const queryClient = createTestQueryClient();
+		const onLabelClick = vi.fn();
+		const bookmarks = [mockBookmark];
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={bookmarks} onLabelClick={onLabelClick} />
+			</QueryClientProvider>,
+		);
+
+		const labelElement = screen.getByText("テスト");
+		fireEvent.click(labelElement);
+
+		expect(onLabelClick).toHaveBeenCalledWith("テスト");
+	});
+
+	test("適切なグリッドレイアウトクラスが適用される", () => {
+		const queryClient = createTestQueryClient();
+		const bookmarks = [mockBookmark];
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={bookmarks} />
+			</QueryClientProvider>,
+		);
+
+		const gridContainer = screen.getByTestId("bookmark-item").parentElement;
+		expect(gridContainer).toHaveClass(
+			"grid",
+			"gap-4",
+			"sm:grid-cols-1",
+			"md:grid-cols-2",
+			"lg:grid-cols-3",
+			"xl:grid-cols-4",
+		);
+	});
+
+	test("各ブックマークアイテムが適切なクラスを持つ", () => {
+		const queryClient = createTestQueryClient();
+		const bookmarks = [mockBookmark];
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<BookmarksList bookmarks={bookmarks} />
+			</QueryClientProvider>,
+		);
+
+		const bookmarkItem = screen.getByTestId("bookmark-item");
+		expect(bookmarkItem).toHaveClass("mx-auto", "w-full", "max-w-sm");
+	});
+});

--- a/frontend/src/features/labels/components/LabelCreateForm.test.tsx
+++ b/frontend/src/features/labels/components/LabelCreateForm.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { LabelCreateForm } from "./LabelCreateForm";
+
+describe("LabelCreateForm", () => {
+	test("フォームが正しく表示される", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(<LabelCreateForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+		expect(screen.getByText("ラベル名")).toBeInTheDocument();
+		expect(screen.getByText("説明文")).toBeInTheDocument();
+		expect(screen.getByText("キャンセル")).toBeInTheDocument();
+		expect(screen.getByText("作成")).toBeInTheDocument();
+	});
+
+	test("ラベル名と説明を入力できる", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(<LabelCreateForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+		const nameInput = screen.getByPlaceholderText("例：react, typescript, aws");
+		const descriptionInput = screen.getByPlaceholderText(
+			"このラベルの説明（MCPの自動ラベリングの参考になります）",
+		);
+
+		fireEvent.change(nameInput, { target: { value: "テストラベル" } });
+		fireEvent.change(descriptionInput, { target: { value: "テスト説明" } });
+
+		expect(nameInput).toHaveValue("テストラベル");
+		expect(descriptionInput).toHaveValue("テスト説明");
+	});
+
+	test("有効な入力でフォーム送信できる", async () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(<LabelCreateForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+		const nameInput = screen.getByPlaceholderText("例：react, typescript, aws");
+		const descriptionInput = screen.getByPlaceholderText(
+			"このラベルの説明（MCPの自動ラベリングの参考になります）",
+		);
+		const submitButton = screen.getByText("作成");
+
+		fireEvent.change(nameInput, { target: { value: "テストラベル" } });
+		fireEvent.change(descriptionInput, { target: { value: "テスト説明" } });
+		fireEvent.click(submitButton);
+
+		await waitFor(() => {
+			expect(mockOnSubmit).toHaveBeenCalledWith("テストラベル", "テスト説明");
+		});
+	});
+
+	test("空のラベル名でフォーム送信時にonSubmitが呼ばれない", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(<LabelCreateForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+		const submitButton = screen.getByText("作成");
+		fireEvent.click(submitButton);
+
+		// バリデーションによりonSubmitが呼ばれないことを確認
+		expect(mockOnSubmit).not.toHaveBeenCalled();
+	});
+
+	test("キャンセルボタンクリックでonCancelが呼ばれる", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(<LabelCreateForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+		const cancelButton = screen.getByText("キャンセル");
+		fireEvent.click(cancelButton);
+
+		expect(mockOnCancel).toHaveBeenCalled();
+	});
+
+	test("送信中は送信ボタンが無効化される", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+
+		render(
+			<LabelCreateForm
+				onSubmit={mockOnSubmit}
+				onCancel={mockOnCancel}
+				isSubmitting={true}
+			/>,
+		);
+
+		const submitButton = screen.getByText("作成中...");
+		expect(submitButton).toBeDisabled();
+	});
+
+	test("エラーが表示される", () => {
+		const mockOnSubmit = vi.fn();
+		const mockOnCancel = vi.fn();
+		const error = new Error("作成に失敗しました");
+
+		render(
+			<LabelCreateForm
+				onSubmit={mockOnSubmit}
+				onCancel={mockOnCancel}
+				error={error}
+			/>,
+		);
+
+		expect(screen.getByText("作成に失敗しました")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- フロントエンドテストカバレッジを2.05%から36.68%に大幅改善
- Issue #507の要件に対応し、優先度の高いコンポーネントと共通コンポーネントにテストを追加

## Test plan
- [ ] 全てのテストがパスすることを確認 ✅
- [ ] カバレッジが30%以上向上することを確認 ✅  
- [ ] リントエラーがないことを確認 ✅
- [ ] TypeCheckエラーがないことを確認 ✅

🤖 Generated with [Claude Code](https://claude.ai/code)