### PR TITLE
feat: フロントエンドCIのカバレッジチェック有効化（Issue #518）

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -59,17 +59,16 @@ jobs:
           echo "$COVERAGE_DETAIL" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # TODO: カバレッジが8割を超えるまで一時的に無効化
-      # - name: Check coverage threshold
-      #   run: |
-      #     COVERAGE=${{ steps.coverage.outputs.coverage }}
-      #     echo "Checking if coverage ($COVERAGE%) meets threshold (80%)..."
-      #     if [ "$(echo "$COVERAGE < 80" | bc -l)" -eq 1 ]; then
-      #       echo "❌ Coverage ($COVERAGE%) is below threshold (80%)"
-      #       exit 1
-      #     else
-      #       echo "✅ Coverage ($COVERAGE%) meets or exceeds threshold (80%)"
-      #     fi
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=${{ steps.coverage.outputs.coverage }}
+          echo "Checking if coverage ($COVERAGE%) meets threshold (80%)..."
+          if [ "$(echo "$COVERAGE < 80" | bc -l)" -eq 1 ]; then
+            echo "❌ Coverage ($COVERAGE%) is below threshold (80%)"
+            exit 1
+          else
+            echo "✅ Coverage ($COVERAGE%) meets or exceeds threshold (80%)"
+          fi
 
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
@@ -80,11 +79,11 @@ jobs:
             ### フロントエンドテストカバレッジレポート
 
             フロントエンド全体のカバレッジ: ${{ steps.coverage.outputs.coverage }}%
-            必要なカバレッジ閾値: 80% (現在は無効化中)
+            必要なカバレッジ閾値: 80%
 
             ${{ steps.coverage.outputs.detail }}
 
-            判定: ✅ カバレッジチェック無効化中（8割到達まで）
+            判定: ${{ steps.coverage.outputs.coverage >= 80 && '✅ カバレッジ閾値（80%）をクリア' || '❌ カバレッジ閾値（80%）未達成' }}
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## 概要
フロントエンドのテストカバレッジが81.68%に達し、80%閾値を上回ったため、CIでのカバレッジチェックを有効化しました。

## 変更内容
- GitHub Actions（`.github/workflows/frontend-lint.yml`）のカバレッジチェックのコメントアウトを解除
- PRコメントの内容を更新し、カバレッジ状況を正確に反映するように修正
- カバレッジが80%未満の場合はCIで失敗するように設定

## 技術的詳細
- 現在のフロントエンドカバレッジ: **81.68%**（Statements）
- 設定されたカバレッジ閾値: **80%**（Statements, Branches, Functions, Lines）
- `vitest.config.ts`で既にカバレッジ閾値は設定済み（Vitestの`thresholds`設定）
- GitHub ActionsでShellスクリプトを使用してカバレッジ値をチェック

## テスト結果
✅ npm run test:coverage - 271テスト全て通過、カバレッジ81.68%
✅ npm run lint - Biome lintチェック通過  
✅ npx tsc --noEmit - TypeScriptタイプチェック通過
✅ npm run format - コードフォーマット確認済み

## 期待される効果
- フロントエンドのコード品質を継続的に維持
- 新しいコードがカバレッジを80%以下に下げる場合、CIで早期検出
- PRレビュー時にカバレッジ情報が自動的にコメントで表示

Closes #518

🤖 Generated with [Claude Code](https://claude.ai/code)