### PR TITLE
fix: RSS読み込み機能でpublishedAtが1970/1/1になる問題を修正 (Issue #503)

### DIFF
--- a/api/src/services/feedProcessor.test.ts
+++ b/api/src/services/feedProcessor.test.ts
@@ -128,6 +128,38 @@ describe("FeedProcessor", () => {
 			);
 		});
 
+		it("publishedAtが正しく保存される", async () => {
+			const publishedDate = new Date("2024-01-01T10:00:00Z");
+			const mockArticles: Article[] = [
+				{
+					guid: "guid1",
+					url: "https://example.com/article1",
+					title: "Article 1",
+					description: "Description 1",
+					publishedAt: publishedDate,
+				},
+			];
+
+			mockFetcher.fetchFeed.mockResolvedValue("<xml>feed data</xml>");
+			mockParser.parseFeed.mockResolvedValue(mockArticles);
+			mockDb.where.mockResolvedValue([]); // 既存URLなし
+			mockDb.returning.mockResolvedValue([{ id: 1 }]);
+
+			await processor.process();
+
+			// RSS記事のinsertでpublishedAtが正しく渡されることを確認
+			expect(mockDb.values).toHaveBeenCalledWith(
+				expect.objectContaining({
+					feedId: mockFeed.id,
+					guid: "guid1",
+					url: "https://example.com/article1",
+					title: "Article 1",
+					description: "Description 1",
+					publishedAt: publishedDate,
+				}),
+			);
+		});
+
 		it("既存の記事を除外して処理する", async () => {
 			const mockArticles: Article[] = [
 				{

--- a/api/src/services/feedProcessor.ts
+++ b/api/src/services/feedProcessor.ts
@@ -191,7 +191,7 @@ export class FeedProcessor {
 						url: article.url,
 						title: article.title,
 						description: article.description || "",
-						// D1はDateオブジェクトを直接扱えないので、必要に応じて変換
+						publishedAt: article.publishedAt,
 					};
 					console.log("Inserting feed item:", JSON.stringify(feedItemData));
 


### PR DESCRIPTION
## 概要
RSS読み込み機能で記事の公開日時が正しく保存されず、1970/1/1のUnix Epochになっていた問題を修正しました。

## 問題の詳細
- RSSフィードから記事を取得する際、`publishedAt`フィールドが抜けていた
- そのため、rssFeedItemsテーブルにNULLまたはデフォルト値（1970/1/1）が保存されていた
- RSS記事の時系列管理が正しく行えない状態だった

## 修正内容
### `api/src/services/feedProcessor.ts`
- `saveArticles`メソッドの`feedItemData`オブジェクトに`publishedAt: article.publishedAt`を追加
- RSS記事のパース済み公開日時を正しくデータベースに保存するよう修正

### `api/src/services/feedProcessor.test.ts`
- TDDアプローチで`publishedAt`が正しく保存されることを検証するテストケースを追加
- `publishedAtが正しく保存される`テストでモックを使用して保存データを検証

## 技術的詳細
- `RSSParser`では既に`article.publishedAt`が正しく解析されていた
- 問題は`FeedProcessor.saveArticles`でのデータベース保存時のフィールド抜けだった
- D1データベースのタイムスタンプ型フィールドにDateオブジェクトを正しく渡すよう修正

## テスト結果
✅ `npm test -- src/services/feedProcessor.test.ts` - 全テスト通過
✅ ログで`publishedAt`が正しく保存されることを確認
✅ 既存のテストも引き続き通過

## 影響範囲
- RSS記事の公開日時が正確に保存されるようになる
- 既存のRSS記事データには影響しない（新規取得分から修正適用）
- フロントエンドでの記事一覧表示で正しい日時が表示される

Closes #503

🤖 Generated with [Claude Code](https://claude.ai/code)