### PR TITLE
fix: RSS管理ページから記事数表示を削除 (Issue #501)

### DIFF
--- a/frontend/src/features/feeds/components/EditFeedModal.test.tsx
+++ b/frontend/src/features/feeds/components/EditFeedModal.test.tsx
@@ -88,7 +88,6 @@ describe("EditFeedModal", () => {
 		updateInterval: 3600,
 		lastFetchedAt: "2024-01-01T00:00:00Z",
 		nextFetchAt: "2024-01-01T01:00:00Z",
-		itemCount: 10,
 		createdAt: "2024-01-01T00:00:00Z",
 		updatedAt: "2024-01-01T00:00:00Z",
 	};
@@ -239,7 +238,6 @@ describe("EditFeedModal", () => {
 			updateInterval: 7200,
 			lastFetchedAt: "2024-01-01T00:00:00Z",
 			nextFetchAt: "2024-01-01T02:00:00Z",
-			itemCount: 5,
 			createdAt: "2024-01-01T00:00:00Z",
 			updatedAt: "2024-01-01T00:00:00Z",
 		};

--- a/frontend/src/features/feeds/components/FeedCard.test.tsx
+++ b/frontend/src/features/feeds/components/FeedCard.test.tsx
@@ -109,7 +109,6 @@ describe("FeedCard", () => {
 		updateInterval: 3600,
 		lastFetchedAt: "2024-01-01T10:00:00Z",
 		nextFetchAt: "2024-01-01T11:00:00Z",
-		itemCount: 15,
 		createdAt: "2024-01-01T00:00:00Z",
 		updatedAt: "2024-01-01T00:00:00Z",
 	};
@@ -136,7 +135,6 @@ describe("FeedCard", () => {
 		expect(
 			screen.getByText("URL: https://example.com/rss"),
 		).toBeInTheDocument();
-		expect(screen.getByText("記事数: 15")).toBeInTheDocument();
 		expect(screen.getByText("編集")).toBeInTheDocument();
 		expect(screen.getByText("削除")).toBeInTheDocument();
 	});
@@ -272,20 +270,6 @@ describe("FeedCard", () => {
 
 		expect(screen.getByText("削除中...")).toBeInTheDocument();
 		expect(screen.getByText("削除中...")).toBeDisabled();
-	});
-
-	it("記事数が0の場合の表示", () => {
-		const feedWithZeroItems = { ...mockFeed, itemCount: 0 };
-		renderWithQueryClient(<FeedCard feed={feedWithZeroItems} />);
-
-		expect(screen.getByText("記事数: 0")).toBeInTheDocument();
-	});
-
-	it("記事数がnullの場合の表示", () => {
-		const feedWithNullItems = { ...mockFeed, itemCount: 0 };
-		renderWithQueryClient(<FeedCard feed={feedWithNullItems} />);
-
-		expect(screen.getByText("記事数: 0")).toBeInTheDocument();
 	});
 
 	it("長いURLが省略表示される", () => {

--- a/frontend/src/features/feeds/components/FeedCard.tsx
+++ b/frontend/src/features/feeds/components/FeedCard.tsx
@@ -76,7 +76,6 @@ export function FeedCard({ feed }: FeedCardProps) {
 					<span className="text-gray-600">
 						最終更新: {formatLastFetch(feed.lastFetchedAt)}
 					</span>
-					<span className="text-gray-600">記事数: {feed.itemCount || 0}</span>
 					<div className="flex items-center gap-1">
 						<span className="text-gray-600">ステータス:</span>
 						<div className={`w-3 h-3 rounded-full ${statusColor}`} />

--- a/frontend/src/features/feeds/queries/useCreateRSSFeed.test.tsx
+++ b/frontend/src/features/feeds/queries/useCreateRSSFeed.test.tsx
@@ -64,7 +64,6 @@ describe("useCreateRSSFeed", () => {
 			updateInterval: 60,
 			nextFetchAt: "2023-01-01T01:00:00Z",
 			lastFetchedAt: null,
-			itemCount: 0,
 		};
 
 		mockFeedsApi.createFeed.mockResolvedValueOnce(mockCreatedFeed);
@@ -139,7 +138,6 @@ describe("useCreateRSSFeed", () => {
 			updateInterval: 60,
 			nextFetchAt: "2023-01-01T01:00:00Z",
 			lastFetchedAt: null,
-			itemCount: 0,
 		});
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/frontend/src/features/feeds/queries/useRSSFeeds.test.tsx
+++ b/frontend/src/features/feeds/queries/useRSSFeeds.test.tsx
@@ -63,7 +63,6 @@ describe("RSSフィード関連フック", () => {
 						updateInterval: 60,
 						nextFetchAt: "2023-01-01T01:00:00Z",
 						lastFetchedAt: null,
-						itemCount: 0,
 					},
 				],
 				total: 1,
@@ -117,7 +116,6 @@ describe("RSSフィード関連フック", () => {
 				updateInterval: 60,
 				nextFetchAt: "2023-01-01T13:00:00Z",
 				lastFetchedAt: null,
-				itemCount: 0,
 			};
 
 			mockFeedsApi.updateFeed.mockResolvedValueOnce(mockUpdatedFeed);

--- a/frontend/src/features/feeds/types.ts
+++ b/frontend/src/features/feeds/types.ts
@@ -6,7 +6,6 @@ export interface RSSFeed {
 	updateInterval: number;
 	lastFetchedAt: string | null;
 	nextFetchAt: string | null;
-	itemCount: number;
 	createdAt: string;
 	updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- RSS管理ページのFeedCardコンポーネントから記事数表示を削除
- RSSFeedインターフェースからitemCountプロパティを削除  
- 関連するすべてのテストファイルからitemCount参照を削除
- DBスキーマにitemCountフィールドが存在しないため、この機能を完全に削除

## Test plan

- [ ] フロントエンドのlint/format/typecheckが通ること
- [ ] 関連するすべてのテストが成功すること
- [ ] RSS管理ページでFeedCardに記事数が表示されないこと
- [ ] その他の機能に影響がないこと

Closes #501

🤖 Generated with [Claude Code](https://claude.ai/code)