### PR TITLE
🔧 フロントエンドデプロイエラー修正 - @ast-grep/napi依存関係問題対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: ./api
 
       - name: Frontend Install dependencies
-        run: npm ci
+        run: npm ci --include=optional
         working-directory: ./frontend
 
       - name: Deploy API


### PR DESCRIPTION
## Summary
• GitHub Actionsでのフロントエンドデプロイ時に発生していた@ast-grep/napi-linux-x64-gnuモジュールが見つからないエラーを修正
• npm ciコマンドに--include=optionalフラグを追加してoptionalDependenciesを確実にインストールするよう変更

## Test plan
- [x] フロントエンドのテストが全て成功することを確認
- [x] リントとフォーマットが正常に動作することを確認  
- [ ] GitHub Actionsでのデプロイが成功することを確認（PRマージ後）

Closes #597

🤖 Generated with [Claude Code](https://claude.ai/code)