### PR TITLE
fix: 評価表示を他のボタンより上に配置して重なりを解消

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -217,7 +217,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 
 			{/* 評価表示 */}
 			{rating ? (
-				<div className="absolute bottom-2 right-24 flex items-center gap-1 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
+				<div className="absolute bottom-10 right-24 flex items-center gap-1 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
 					<StarRating score={rating.totalScore} size="sm" />
 					<Link
 						href={`/ratings?articleId=${id}`}
@@ -228,7 +228,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					</Link>
 				</div>
 			) : (
-				<div className="absolute bottom-2 right-24 flex items-center gap-1 bg-gray-50 border border-gray-200 rounded-full px-2 py-1">
+				<div className="absolute bottom-10 right-24 flex items-center gap-1 bg-gray-50 border border-gray-200 rounded-full px-2 py-1">
 					<span className="text-xs text-gray-500">未評価</span>
 					<span
 						className="text-xs text-blue-600"


### PR DESCRIPTION
## 概要
BookmarkCardコンポーネントの評価表示が他のボタンと重なってしまう問題を修正しました。

## 関連Issue
Fixes #628

## 変更内容
- 評価表示（評価済み・未評価）の位置を`bottom-2`から`bottom-10`に変更
- これにより、評価表示がラベルやボタン類より1段上に配置されるようになり、重なりが解消されます

## スクリーンショット
評価表示が他のUI要素と重ならず、独立して上部に表示されるようになりました。

## テスト
- [x] 既存のBookmarkCardコンポーネントのテストが全てパス
- [x] リント・タイプチェックが全てパス

## 補足
TailwindCSSのクラスを使用して位置調整を行いました。`bottom-10`により、評価表示が他のボタン群から適切な距離を保って配置されます。

🤖 Generated with [Claude Code](https://claude.ai/code)