### PR TITLE
🐛 fix: 評価が存在しない場合の404レスポンス修正

### DIFF
--- a/api/src/routes/ratings.ts
+++ b/api/src/routes/ratings.ts
@@ -142,7 +142,13 @@ export const createRatingsRouter = (ratingService: IRatingService) => {
 			const rating = await ratingService.getRating(articleId);
 
 			if (!rating) {
-				throw new NotFoundError("指定された記事の評価が見つかりません");
+				return c.json(
+					{
+						success: false,
+						message: "指定された記事の評価が見つかりません",
+					},
+					404,
+				);
 			}
 
 			return c.json({


### PR DESCRIPTION
## 概要
MCPからは評価済みと確認できる記事がUIでは未評価となる問題 (#632) を修正しました。

## 修正内容
- `GET /api/bookmarks/:id/rating` エンドポイントで評価が存在しない場合の処理を修正
- `NotFoundError` を投げる代わりに、適切な404ステータスレスポンスを返すよう変更
- フロントエンドは既に404レスポンスを正しく処理する実装になっているため、これにより問題が解決します

## 修正箇所
- `api/src/routes/ratings.ts` (144-151行目)

## テスト結果
- 既存のテストは全てパス (324 passed)
- リント・フォーマットチェック: OK

## 関連Issue
Closes #632

🤖 Generated with [Claude Code](https://claude.ai/code)