### PR TITLE
🔧 refactor: 残りのサービス層への新しい例外処理システム適用完了

### DIFF
--- a/api/src/services/rssFeed.ts
+++ b/api/src/services/rssFeed.ts
@@ -1,5 +1,5 @@
-import { HTTPException } from "hono/http-exception";
 import type { InsertRssFeed, RssFeed } from "../db/schema";
+import { NotFoundError } from "../exceptions";
 import type { RssFeedRepository } from "../interfaces/repository/rssFeed";
 import type { RssFeedService as IRssFeedService } from "../interfaces/service/rssFeed";
 
@@ -13,9 +13,7 @@ export class RssFeedService implements IRssFeedService {
 	async getFeedById(id: number): Promise<RssFeed> {
 		const feed = await this.repository.findById(id);
 		if (!feed) {
-			throw new HTTPException(404, {
-				message: `RSSフィードが見つかりません: ID ${id}`,
-			});
+			throw new NotFoundError(`RSSフィードが見つかりません: ID ${id}`);
 		}
 		return feed;
 	}
@@ -28,9 +26,7 @@ export class RssFeedService implements IRssFeedService {
 	async updateFeed(id: number, data: Partial<InsertRssFeed>): Promise<RssFeed> {
 		const updatedFeed = await this.repository.update(id, data);
 		if (!updatedFeed) {
-			throw new HTTPException(404, {
-				message: `RSSフィードが見つかりません: ID ${id}`,
-			});
+			throw new NotFoundError(`RSSフィードが見つかりません: ID ${id}`);
 		}
 		return updatedFeed;
 	}
@@ -38,9 +34,7 @@ export class RssFeedService implements IRssFeedService {
 	async deleteFeed(id: number): Promise<void> {
 		const success = await this.repository.delete(id);
 		if (!success) {
-			throw new HTTPException(404, {
-				message: `RSSフィードが見つかりません: ID ${id}`,
-			});
+			throw new NotFoundError(`RSSフィードが見つかりません: ID ${id}`);
 		}
 	}
 }

--- a/api/src/services/rssFetcher.ts
+++ b/api/src/services/rssFetcher.ts
@@ -1,6 +1,8 @@
 /**
  * RSSフィードを取得するサービス
  */
+import { ExternalServiceError, TimeoutError } from "../exceptions";
+
 export class RSSFetcher {
 	/**
 	 * 指定されたURLからRSSフィードを取得する
@@ -26,7 +28,10 @@ export class RSSFetcher {
 				}),
 				// 30秒でタイムアウト
 				new Promise<never>((_, reject) =>
-					setTimeout(() => reject(new Error("RSS fetch timeout")), 30000),
+					setTimeout(
+						() => reject(new TimeoutError("RSS fetch timeout")),
+						30000,
+					),
 				),
 			]);
 
@@ -34,7 +39,7 @@ export class RSSFetcher {
 			console.log(`RSSフィード取得完了: ${url} (${elapsedTime}ms)`);
 
 			if (!response.ok) {
-				throw new Error(
+				throw new ExternalServiceError(
 					`Failed to fetch RSS: ${response.status} ${response.statusText}`,
 				);
 			}


### PR DESCRIPTION
## Summary
- PR #636で一部のファイルのみ対応されたissue #631の残り作業を完了
- services/rssFeed.ts: HTTPException → NotFoundError に変更
- services/rssFetcher.ts: Error → ExternalServiceError, TimeoutError に変更
- エラーハンドリングの一貫性を向上し、適切なHTTPステータスコードが返るように改善

## Test plan
- [x] 既存のテストがすべてパス
- [x] lint/format checks を通過
- [x] 変更されたファイルのエラーハンドリングが正しく動作することを確認

## Related
- Closes #631

🤖 Generated with [Claude Code](https://claude.ai/code)