### PR TITLE
✨ feat: Dependabot設定にreviewer/assigneeを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       prefix: "chore(frontend)"
       prefix-development: "chore(frontend-dev)"
       include: "scope"
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
     groups:
       core-dependencies:
         patterns:
@@ -55,6 +59,10 @@ updates:
       prefix: "chore(api)"
       prefix-development: "chore(api-dev)"
       include: "scope"
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
     # ここで特定パッケージをグルーピング
     groups:
       core-dependencies:
@@ -95,6 +103,10 @@ updates:
       prefix: "chore(extension)"
       prefix-development: "chore(extension-dev)"
       include: "scope"
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
     # ここで特定パッケージをグルーピング
     groups:
       devdependencies:
@@ -112,6 +124,10 @@ updates:
       prefix: "chore(mcp)"
       prefix-development: "chore(mcp-dev)"
       include: "scope"
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
     # ここで特定パッケージをグルーピング
     groups:
       core-dependencies:
@@ -144,3 +160,7 @@ updates:
       prefix: "chore(actions)"
       prefix-development: "chore(actions)"
       include: "scope"
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"


### PR DESCRIPTION
## 概要

Issue #651に対応して、Dependabot設定にreviewer/assigneeを追加しました。

## 変更内容

- `.github/dependabot.yml`の全てのupdateセクション（frontend、api、extension、mcp、github-actions）に以下を追加：
  - `reviewers: ["ryosuke-horie"]`
  - `assignees: ["ryosuke-horie"]`

## 効果

今後DependabotがPRを作成する際に、自動的にryosuke-horieがreviewerとassigneeに設定されるようになります。

Closes #651

🤖 Generated with [Claude Code](https://claude.ai/code)