### PR TITLE
🐛 fix: RSS記事の日付が1970年になる問題を修正

### DIFF
--- a/api/src/services/feedProcessor.ts
+++ b/api/src/services/feedProcessor.ts
@@ -174,7 +174,8 @@ export class FeedProcessor {
 						url: article.url,
 						title: article.title,
 						isRead: false,
-						// D1はDateオブジェクトを直接扱えないので、必要に応じて変換
+						createdAt: article.publishedAt || new Date(),
+						updatedAt: new Date(),
 					};
 					console.log("Inserting bookmark:", JSON.stringify(bookmarkData));
 


### PR DESCRIPTION
## Summary
- RSS記事から作成されるブックマークで正しい公開日時が表示されるように修正
- FeedProcessorでpublishedAtをcreatedAtに設定する処理を追加

## Changes
- `api/src/services/feedProcessor.ts`: saveArticlesメソッドでpublishedAtをcreatedAtに設定
- `api/src/services/feedProcessor.test.ts`: 日付設定の動作を検証するテストを追加

## Test plan
- [x] feedProcessor.test.tsで全テストがパス
- [x] publishedAtがある場合の動作確認
- [x] publishedAtがない場合のフォールバック動作確認

Closes #652

🤖 Generated with [Claude Code](https://claude.ai/code)