### PR TITLE
RatingDisplayコンポーネントの「未評価」表示を削除

### DIFF
--- a/frontend/src/features/bookmarks/components/RatingDisplay.test.tsx
+++ b/frontend/src/features/bookmarks/components/RatingDisplay.test.tsx
@@ -57,15 +57,18 @@ describe("RatingDisplay", () => {
 		expect(screen.getByTitle("評価詳細を見る")).toBeInTheDocument();
 	});
 
-	it("評価がない場合、未評価表示をする", () => {
+	it("評価がない場合、何も表示しない", () => {
 		// 評価データをnullに設定（デフォルト）
 		mockRatingData = null;
 
-		renderWithQueryClient(<RatingDisplay bookmarkId={1} />);
+		const { container } = renderWithQueryClient(
+			<RatingDisplay bookmarkId={1} />,
+		);
 
-		expect(screen.getByText("未評価")).toBeInTheDocument();
-		expect(screen.getByText("📝")).toBeInTheDocument();
-		expect(screen.getByTitle("Claude (MCP) で評価可能")).toBeInTheDocument();
+		// コンポーネントが何もレンダリングしないことを確認
+		expect(container.firstChild).toBeNull();
+		expect(screen.queryByText("未評価")).not.toBeInTheDocument();
+		expect(screen.queryByText("📝")).not.toBeInTheDocument();
 	});
 
 	it("評価詳細リンクが正しいURLを指している", () => {

--- a/frontend/src/features/bookmarks/components/RatingDisplay.tsx
+++ b/frontend/src/features/bookmarks/components/RatingDisplay.tsx
@@ -15,30 +15,23 @@ interface Props {
 export function RatingDisplay({ bookmarkId }: Props) {
 	const { data: rating } = useArticleRating(bookmarkId);
 
+	// 評価がない場合は何も表示しない
+	if (!rating) {
+		return null;
+	}
+
 	return (
 		<div className="absolute bottom-10 right-24">
-			{rating ? (
-				<div className="flex items-center gap-1 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
-					<StarRating score={rating.totalScore} size="sm" />
-					<Link
-						href={`/ratings?articleId=${bookmarkId}`}
-						className="text-xs text-blue-600 hover:text-blue-700 ml-1"
-						title="評価詳細を見る"
-					>
-						詳細
-					</Link>
-				</div>
-			) : (
-				<div className="flex items-center gap-1 bg-gray-50 border border-gray-200 rounded-full px-2 py-1">
-					<span className="text-xs text-gray-500">未評価</span>
-					<span
-						className="text-xs text-blue-600"
-						title="Claude (MCP) で評価可能"
-					>
-						📝
-					</span>
-				</div>
-			)}
+			<div className="flex items-center gap-1 bg-white border border-gray-200 rounded-full px-2 py-1 shadow-sm">
+				<StarRating score={rating.totalScore} size="sm" />
+				<Link
+					href={`/ratings?articleId=${bookmarkId}`}
+					className="text-xs text-blue-600 hover:text-blue-700 ml-1"
+					title="評価詳細を見る"
+				>
+					詳細
+				</Link>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
評価がない場合に表示されていた「未評価 📝」の表示を削除し、何も表示しないよう変更

## Changes
- `RatingDisplay.tsx`: 評価データがnullの場合にnullを返すよう修正し、未評価表示UIを削除
- `RatingDisplay.test.tsx`: 未評価時のテストケースを「何も表示しない」ことを検証するよう変更

## Test plan
- [x] npm test でユニットテストが全て通過することを確認
- [x] npm run lint, npx tsc --noEmit でコード品質チェックが通過することを確認
- [x] 評価がない場合にコンポーネントが何もレンダリングしないことをテストで検証

Closes #668

🤖 Generated with [Claude Code](https://claude.ai/code)