### PR TITLE
🎨 UI：BookmarkCardの高さを固定し、タイトルの省略表示を改善

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -76,7 +76,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 
 	return (
 		<article
-			className={`relative p-4 pb-16 border rounded-lg hover:shadow-md transition-shadow flex flex-col min-h-[150px] ${
+			className={`relative p-4 pb-16 border rounded-lg hover:shadow-md transition-shadow flex flex-col h-[200px] ${
 				isRead ? "bg-gray-50" : ""
 			}`}
 		>
@@ -344,7 +344,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 
 			{/* コンテンツ */}
 			<h2
-				className="font-bold mb-2 line-clamp-2"
+				className="font-bold mb-2 line-clamp-3"
 				title={title || "タイトルなし"}
 			>
 				<a


### PR DESCRIPTION
## 変更内容

### 概要
Issue #662で報告されたUI改善を実装しました。BookmarkCardコンポーネントのカード高さを固定し、長いタイトルの表示を改善しました。

### 変更詳細
- カードの高さを `min-h-[150px]` から `h-[200px]` に変更し、統一した高さに固定
- タイトルの行制限を `line-clamp-2` から `line-clamp-3` に変更し、より多くの情報を表示
- URL部分は既存の `line-clamp-1` を維持

### 期待される効果
- カード全体の見た目の統一感が向上
- タイトルが長い記事でも、より多くの情報が見えるようになる
- レイアウトの安定性が向上

### テスト
- ✅ リント・フォーマット・タイプチェック通過
- ✅ 開発サーバーでの動作確認済み

## 対応するIssue
Closes #662

🤖 Generated with [Claude Code](https://claude.ai/code)