### PR TITLE
feat: 表示順を新しい順に変更 (Issue #686)

### DIFF
--- a/api/src/repositories/bookmark.ts
+++ b/api/src/repositories/bookmark.ts
@@ -1,4 +1,13 @@
-import { type SQL, and, count, eq, gte, inArray, isNull } from "drizzle-orm";
+import {
+	type SQL,
+	and,
+	count,
+	desc,
+	eq,
+	gte,
+	inArray,
+	isNull,
+} from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
 import {
@@ -315,7 +324,7 @@ export class DrizzleBookmarkRepository implements IBookmarkRepository {
 						gte(bookmarks.updatedAt, threeDaysAgo),
 					),
 				)
-				.orderBy(bookmarks.updatedAt);
+				.orderBy(desc(bookmarks.updatedAt));
 
 			const results = await query.all();
 
@@ -368,7 +377,7 @@ export class DrizzleBookmarkRepository implements IBookmarkRepository {
 				.leftJoin(articleLabels, eq(bookmarks.id, articleLabels.articleId))
 				.leftJoin(labels, eq(articleLabels.labelId, labels.id))
 				.where(eq(bookmarks.isRead, true))
-				.orderBy(bookmarks.updatedAt);
+				.orderBy(desc(bookmarks.updatedAt));
 
 			const results = await query.all();
 

--- a/api/tests/unit/repositories/bookmark.test.ts
+++ b/api/tests/unit/repositories/bookmark.test.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, isNull } from "drizzle-orm";
+import { desc, eq, inArray, isNull } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type Bookmark,
@@ -224,7 +224,9 @@ describe("ブックマークリポジトリ", () => {
 			expect(mockDbClient.select).toHaveBeenCalled();
 			expect(mockDbClient.from).toHaveBeenCalledWith(bookmarks);
 			expect(mockDbClient.where).toHaveBeenCalledWith(expect.anything());
-			expect(mockDbClient.orderBy).toHaveBeenCalledWith(bookmarks.updatedAt);
+			expect(mockDbClient.orderBy).toHaveBeenCalledWith(
+				desc(bookmarks.updatedAt),
+			);
 			expect(mockDbClient.leftJoin).toHaveBeenCalledTimes(3);
 			expect(mockDbClient.all).toHaveBeenCalledOnce();
 		});


### PR DESCRIPTION
## Summary

Issue #686の対応として、ブックマークリストの表示順を古い順から新しい順（降順）に変更しました。

- ブックマークの最近読んだ記事とお気に入り記事の表示順が新しい順になります
- ユーザーが最新の記事を最初に見つけやすくなります

## 変更内容

- `DrizzleBookmarkRepository` の `findRecentlyRead()` と `findRead()` メソッドで `desc()` 関数を使用してソート順を変更
- `drizzle-orm` から `desc` 関数をインポート
- 対応するテストケースも更新

## Test plan

- [x] 既存のテストが全て通ることを確認
- [x] Lint と フォーマットが正しく適用されることを確認
- [ ] 開発環境でブックマークリストの表示順が新しい順になることを確認

Closes #686

🤖 Generated with [Claude Code](https://claude.ai/code)