### PR TITLE
🔧 fix: エラーハンドリングの統一化とレスポンス形式の一貫性確保 (Issue #676)

### DIFF
--- a/api/src/routes/bookmarks.ts
+++ b/api/src/routes/bookmarks.ts
@@ -241,9 +241,13 @@ export const createBookmarksRouter = (
 				return c.json(createErrorResponseBody(notFoundError), 404);
 			}
 			console.error("Failed to mark bookmark as read:", error);
+			const internalError = new InternalServerError(
+				"Failed to mark bookmark as read",
+			);
+			const errorResponse = createErrorResponse(internalError);
 			return c.json(
-				{ success: false, message: "Failed to mark bookmark as read" },
-				500,
+				createErrorResponseBody(internalError),
+				errorResponse.statusCode,
 			);
 		}
 	});
@@ -261,11 +265,10 @@ export const createBookmarksRouter = (
 				return c.json(createErrorResponseBody(notFoundError), 404);
 			}
 			console.error("Failed to mark bookmark as unread:", error);
-			// For general errors, preserve the original error message format
-			return c.json(
-				{ success: false, message: "Failed to mark bookmark as unread" },
-				500,
+			const internalError = new InternalServerError(
+				"Failed to mark bookmark as unread",
 			);
+			return c.json(createErrorResponseBody(internalError), 500);
 		}
 	});
 


### PR DESCRIPTION
## Summary
- Issue #676で指摘されたbookmarks.tsのエラーハンドリング不統一を修正
- `/:id/read`と`/:id/unread`エンドポイントで直接的なエラーレスポンス形式を使用していた箇所を、統一的な`createErrorResponseBody`関数を使用するよう変更
- API全体でのエラーレスポンス形式の一貫性を確保

## 変更内容
### 修正前
```typescript
return c.json(
  { success: false, message: "Failed to mark bookmark as read" },
  500,
);
```

### 修正後
```typescript
const internalError = new InternalServerError("Failed to mark bookmark as read");
return c.json(createErrorResponseBody(internalError), 500);
```

## Test plan
- [x] 既存のユニットテスト全262件が正常にパス
- [x] エラーハンドリングの変更による既存機能への影響なし
- [x] 統一的なエラーレスポンス形式が使用されていることを確認

## 期待される効果
- フロントエンド側でのエラーハンドリング統一
- API仕様の一貫性向上
- デバッグ効率の改善

🤖 Generated with [Claude Code](https://claude.ai/code)