### PR TITLE
✨ feat: 未読ブックマークの表示順を作成日時の降順に変更

### DIFF
--- a/api/tests/unit/repositories/bookmark.test.ts
+++ b/api/tests/unit/repositories/bookmark.test.ts
@@ -144,6 +144,22 @@ describe("ブックマークリポジトリ", () => {
 			expect(mockDbClient.all).toHaveBeenCalledOnce();
 		});
 
+		it("未読ブックマークを作成日時の降順でソートして取得できること", async () => {
+			mockDbClient.all.mockResolvedValue([mockQueryResult2, mockQueryResult1]);
+			const result = await repository.findUnread();
+			expect(result).toEqual([expectedResult2, expectedResult1]);
+			expect(mockDbClient.select).toHaveBeenCalled();
+			expect(mockDbClient.from).toHaveBeenCalledWith(bookmarks);
+			expect(mockDbClient.where).toHaveBeenCalledWith(
+				eq(bookmarks.isRead, false),
+			);
+			expect(mockDbClient.orderBy).toHaveBeenCalledWith(
+				desc(bookmarks.createdAt),
+			);
+			expect(mockDbClient.leftJoin).toHaveBeenCalledTimes(3);
+			expect(mockDbClient.all).toHaveBeenCalledOnce();
+		});
+
 		it("DBクエリ失敗時にエラーをスローすること", async () => {
 			const mockError = new Error("Database error");
 			mockDbClient.all.mockRejectedValue(mockError);


### PR DESCRIPTION
## Summary
未読ブックマーク一覧で新しい記事が上に表示されるよう、表示順を作成日時の降順に変更しました。

- BookmarkRepository.findUnread()メソッドにorderBy(desc(bookmarks.createdAt))を追加
- 他のメソッド（findRecentlyRead、findRead）と一貫性を保つソート順で統一
- ソート機能のテストケースを追加

## Test plan
- [x] ユニットテストの実装と実行
- [x] 未読ブックマークが作成日時の降順でソートされることを確認
- [x] 既存テストが引き続き通ることを確認

Closes #691

🤖 Generated with [Claude Code](https://claude.ai/code)