### PR TITLE
fix: ラベルフィルタ時のブックマーク並び順を作成日時降順に修正 (Issue #711)

### DIFF
--- a/api/src/repositories/bookmark.ts
+++ b/api/src/repositories/bookmark.ts
@@ -433,6 +433,7 @@ export class DrizzleBookmarkRepository implements IBookmarkRepository {
 						eq(bookmarks.isRead, false), // 未読記事のみを取得
 					),
 				)
+				.orderBy(desc(bookmarks.createdAt))
 				.all();
 
 			return results.map((row) => ({

--- a/api/tests/unit/repositories/bookmark.test.ts
+++ b/api/tests/unit/repositories/bookmark.test.ts
@@ -331,6 +331,35 @@ describe("ブックマークリポジトリ", () => {
 			expect(mockDbClient.all).toHaveBeenCalledOnce();
 		});
 
+		it("ラベル名によるブックマークを作成日時の降順でソートして取得できること", async () => {
+			const labelName = "typescript";
+			mockDbClient.all.mockResolvedValue([
+				{
+					bookmark: mockBookmark2,
+					favorite: null,
+					label: mockLabel1,
+				},
+				{
+					bookmark: mockBookmark1,
+					favorite: { id: 1, bookmarkId: 1, createdAt: new Date() },
+					label: mockLabel1,
+				},
+			]);
+			const result = await repository.findByLabelName(labelName);
+			// 両方ともmockLabel1を使用するよう期待値を修正
+			const expectedResultsWithLabel1 = [
+				{ ...expectedResult2, label: mockLabel1 },
+				{ ...expectedResult1, label: mockLabel1 },
+			];
+			expect(result).toEqual(expectedResultsWithLabel1);
+			expect(mockDbClient.select).toHaveBeenCalled();
+			expect(mockDbClient.from).toHaveBeenCalledWith(bookmarks);
+			expect(mockDbClient.orderBy).toHaveBeenCalledWith(
+				desc(bookmarks.createdAt),
+			);
+			expect(mockDbClient.all).toHaveBeenCalledOnce();
+		});
+
 		it("DBクエリ失敗時にエラーをスローすること", async () => {
 			const labelName = "typescript";
 			const mockError = new Error("Database error");


### PR DESCRIPTION
<\!-- 
GitHub Copilot コードレビューへの指示： 
- このプルリクエストをレビューしてコメントする時は日本語でお願いします。
- 後々意味をなさないコメントが含まれる場合は常に指摘してください。
-->

## 修正内容

Issue #711 で報告されたラベルフィルタ時のブックマーク並び順の問題を修正しました。

### 変更詳細

- ラベルフィルタ適用時のブックマーク一覧で、作成日時の降順（新しい順）で表示されるように修正
- `getUnreadBookmarksByLabel` 関数のクエリに `ORDER BY created_at DESC` を追加
- ユーザーが最新の記事から確認できるように改善

### 影響範囲

- ラベル別未読ブックマーク一覧の表示順のみに影響
- 既存の機能には影響なし

### テスト

- 既存のテストケースが正常に通ることを確認
- ラベルフィルタ時の並び順が期待通りに動作することを確認

Closes #711