### PR TITLE
🔧 Biome v1からv2へのマイグレーション

### DIFF
--- a/.github/workflows/mcp-test.yml
+++ b/.github/workflows/mcp-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
       
       - name: Run tests with coverage
-        run: npm run test:coverage
+        run: npm run test:ci:coverage
       
       - name: Extract coverage percentage
         run: |

--- a/api/biome.json
+++ b/api/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,25 +7,36 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": [
-			"node_modules",
-			".wrangler",
-			"drizzle.config.ts",
-			"coverage",
-			"drizzle/**"
+		"includes": [
+			"**",
+			"!**/node_modules",
+			"!**/.wrangler",
+			"!**/drizzle.config.ts",
+			"!**/coverage",
+			"!**/drizzle/**"
 		]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
 		}
 	},
 	"javascript": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,7 @@
 				"hono": "^4.7.11"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "1.9.4",
+				"@biomejs/biome": "2.0.5",
 				"@cloudflare/workers-types": "^4.20250607.0",
 				"@types/node": "^22.15.30",
 				"@vitest/coverage-v8": "3.2.3",
@@ -99,11 +99,10 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.5.tgz",
+			"integrity": "sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -116,20 +115,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.0.5",
+				"@biomejs/cli-darwin-x64": "2.0.5",
+				"@biomejs/cli-linux-arm64": "2.0.5",
+				"@biomejs/cli-linux-arm64-musl": "2.0.5",
+				"@biomejs/cli-linux-x64": "2.0.5",
+				"@biomejs/cli-linux-x64-musl": "2.0.5",
+				"@biomejs/cli-win32-arm64": "2.0.5",
+				"@biomejs/cli-win32-x64": "2.0.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.5.tgz",
+			"integrity": "sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==",
 			"cpu": [
 				"arm64"
 			],
@@ -144,9 +143,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+			"integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
 			"cpu": [
 				"x64"
 			],
@@ -161,9 +160,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+			"integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -178,9 +177,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+			"integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
 			"cpu": [
 				"arm64"
 			],
@@ -195,9 +194,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+			"integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
 			"cpu": [
 				"x64"
 			],
@@ -212,9 +211,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+			"integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
 			"cpu": [
 				"x64"
 			],
@@ -229,9 +228,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+			"integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -246,9 +245,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+			"integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
 			"cpu": [
 				"x64"
 			],

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,7 @@
 		"hono": "^4.7.11"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
+		"@biomejs/biome": "2.0.5",
 		"@cloudflare/workers-types": "^4.20250607.0",
 		"@types/node": "^22.15.30",
 		"@vitest/coverage-v8": "3.2.3",

--- a/api/src/exceptions/index.ts
+++ b/api/src/exceptions/index.ts
@@ -5,34 +5,32 @@
 
 // 基底クラス
 export { BaseError, HttpError } from "./base";
-
-// HTTPエラー
-export {
-	BadRequestError,
-	UnauthorizedError,
-	ForbiddenError,
-	NotFoundError,
-	ConflictError,
-	ValidationError,
-	InternalServerError,
-	ServiceUnavailableError,
-} from "./http";
-
 // ビジネスエラー
 export {
 	DatabaseError,
-	ExternalServiceError,
 	DuplicateResourceError,
-	TimeoutError,
-	RSSError,
+	ExternalServiceError,
 	RateLimitError,
+	RSSError,
+	TimeoutError,
 } from "./business";
+// HTTPエラー
+export {
+	BadRequestError,
+	ConflictError,
+	ForbiddenError,
+	InternalServerError,
+	NotFoundError,
+	ServiceUnavailableError,
+	UnauthorizedError,
+	ValidationError,
+} from "./http";
 
 // エラーハンドリングユーティリティ
 export {
-	isOperationalError,
 	createErrorResponse,
 	createErrorResponseBody,
+	isOperationalError,
 } from "./utils";
 
 if (import.meta.vitest) {

--- a/api/src/interfaces/service/rating.ts
+++ b/api/src/interfaces/service/rating.ts
@@ -1,7 +1,7 @@
 /**
  * 記事評価ポイントのサービスインターフェース
  */
-import type { ArticleRating, InsertArticleRating } from "../../db/schema";
+import type { ArticleRating } from "../../db/schema";
 import type { FindManyOptions, RatingStats } from "../repository/articleRating";
 
 export interface IRatingService {

--- a/api/src/repositories/articleLabel.ts
+++ b/api/src/repositories/articleLabel.ts
@@ -2,8 +2,8 @@ import { eq, inArray } from "drizzle-orm";
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import {
 	type ArticleLabel,
-	type InsertArticleLabel,
 	articleLabels,
+	type InsertArticleLabel,
 } from "../db/schema";
 import type { IArticleLabelRepository } from "../interfaces/repository/articleLabel";
 

--- a/api/src/repositories/articleRating.ts
+++ b/api/src/repositories/articleRating.ts
@@ -2,7 +2,6 @@
  * 記事評価ポイントのリポジトリ実装
  */
 import {
-	type SQL,
 	and,
 	asc,
 	avg,
@@ -14,14 +13,14 @@ import {
 	isNull,
 	lte,
 	or,
+	type SQL,
 } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
 import {
 	type ArticleRating,
-	type InsertArticleRating,
 	articleRatings,
-	bookmarks,
+	type InsertArticleRating,
 } from "../db/schema";
 import { DatabaseError, NotFoundError } from "../exceptions";
 import type {

--- a/api/src/repositories/bookmark.ts
+++ b/api/src/repositories/bookmark.ts
@@ -1,13 +1,13 @@
-import { type SQL, and, count, eq, gte, inArray, isNull } from "drizzle-orm";
+import { and, count, eq, gte, inArray, isNull, type SQL } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { drizzle } from "drizzle-orm/d1";
 import {
-	type Bookmark,
-	type InsertBookmark,
 	articleLabels,
 	articleRatings,
+	type Bookmark,
 	bookmarks,
 	favorites,
+	type InsertBookmark,
 	labels,
 } from "../db/schema";
 import { ConflictError, NotFoundError } from "../exceptions";

--- a/api/src/repositories/label.ts
+++ b/api/src/repositories/label.ts
@@ -1,9 +1,9 @@
 import { count, eq } from "drizzle-orm";
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import {
+	articleLabels,
 	type InsertLabel,
 	type Label,
-	articleLabels,
 	labels,
 } from "../db/schema";
 import type { ILabelRepository } from "../interfaces/repository/label";

--- a/api/src/repositories/rssFeed.ts
+++ b/api/src/repositories/rssFeed.ts
@@ -53,12 +53,12 @@ export class RssFeedRepository implements IRssFeedRepository {
 
 	async delete(id: number): Promise<boolean> {
 		try {
-			const result = await this.db
+			const _result = await this.db
 				.delete(rssFeeds)
 				.where(eq(rssFeeds.id, id))
 				.get();
 			return true;
-		} catch (error) {
+		} catch (_error) {
 			return false;
 		}
 	}

--- a/api/src/repositories/rssFeedItem.ts
+++ b/api/src/repositories/rssFeedItem.ts
@@ -45,7 +45,7 @@ export class RssFeedItemRepository {
 	}
 
 	async createMany(items: InsertRssFeedItem[]): Promise<number> {
-		const result = await this.db.insert(rssFeedItems).values(items).all();
+		const _result = await this.db.insert(rssFeedItems).values(items).all();
 
 		return items.length;
 	}

--- a/api/src/routes/bookmarks.ts
+++ b/api/src/routes/bookmarks.ts
@@ -2,10 +2,10 @@ import { Hono } from "hono";
 import {
 	BadRequestError,
 	ConflictError,
-	InternalServerError,
-	NotFoundError,
 	createErrorResponse,
 	createErrorResponseBody,
+	InternalServerError,
+	NotFoundError,
 } from "../exceptions";
 import type { BookmarkWithLabel } from "../interfaces/repository/bookmark";
 import type { IBookmarkService } from "../interfaces/service/bookmark";
@@ -76,7 +76,7 @@ export const createBookmarksRouter = (
 			let body: { labelName?: string };
 			try {
 				body = await c.req.json<{ labelName?: string }>();
-			} catch (e) {
+			} catch (_e) {
 				throw new BadRequestError("Invalid request body");
 			}
 

--- a/api/src/routes/labels.ts
+++ b/api/src/routes/labels.ts
@@ -2,10 +2,10 @@ import { Hono } from "hono";
 import {
 	BadRequestError,
 	ConflictError,
-	InternalServerError,
-	NotFoundError,
 	createErrorResponse,
 	createErrorResponseBody,
+	InternalServerError,
+	NotFoundError,
 } from "../exceptions";
 import type { Env } from "../index";
 import { ArticleLabelRepository } from "../repositories/articleLabel";

--- a/api/src/routes/ratings.ts
+++ b/api/src/routes/ratings.ts
@@ -6,11 +6,10 @@ import { z } from "zod";
 import {
 	BadRequestError,
 	ConflictError,
-	DatabaseError,
-	NotFoundError,
-	ValidationError,
 	createErrorResponse,
 	createErrorResponseBody,
+	NotFoundError,
+	ValidationError,
 } from "../exceptions";
 import type { IRatingService } from "../interfaces/service/rating";
 

--- a/api/src/routes/rssFeeds.ts
+++ b/api/src/routes/rssFeeds.ts
@@ -1,10 +1,8 @@
 import { Hono } from "hono";
 import {
-	BadRequestError,
-	InternalServerError,
-	NotFoundError,
 	createErrorResponse,
 	createErrorResponseBody,
+	NotFoundError,
 } from "../exceptions";
 import type { RssFeedService } from "../services/rssFeed";
 

--- a/api/src/services/bookmark.ts
+++ b/api/src/services/bookmark.ts
@@ -49,7 +49,7 @@ export class DefaultBookmarkService implements IBookmarkService {
 	}> {
 		try {
 			// 個人ツールではページネーション不要のため、全件取得
-			const { bookmarks, total } = await this.repository.getFavoriteBookmarks(
+			const { bookmarks } = await this.repository.getFavoriteBookmarks(
 				0,
 				1000,
 			);

--- a/api/src/services/feedProcessor.ts
+++ b/api/src/services/feedProcessor.ts
@@ -1,13 +1,7 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import {
-	type Bookmark,
-	type RssFeedItem,
-	bookmarks,
-	rssFeedItems,
-	rssFeeds,
-} from "../db/schema";
+import { bookmarks, rssFeedItems, rssFeeds } from "../db/schema";
 import { DatabaseError } from "../exceptions";
 import type { Article } from "../types/rss";
 import { RSSBatchProcessor } from "./batchProcessor";

--- a/api/src/services/rating.ts
+++ b/api/src/services/rating.ts
@@ -8,9 +8,9 @@ import {
 	NotFoundError,
 	ValidationError,
 } from "../exceptions";
-import type { IArticleRatingRepository } from "../interfaces/repository/articleRating";
 import type {
 	FindManyOptions,
+	IArticleRatingRepository,
 	RatingStats,
 } from "../interfaces/repository/articleRating";
 import type { IBookmarkRepository } from "../interfaces/repository/bookmark";

--- a/api/src/workers/rssBatch.ts
+++ b/api/src/workers/rssBatch.ts
@@ -9,9 +9,9 @@ export interface Env {
 
 export default {
 	async scheduled(
-		controller: ScheduledController,
+		_controller: ScheduledController,
 		env: Env,
-		ctx: ExecutionContext,
+		_ctx: ExecutionContext,
 	): Promise<void> {
 		console.log("RSS バッチ処理開始");
 

--- a/api/tests/test-utils.ts
+++ b/api/tests/test-utils.ts
@@ -1,4 +1,3 @@
-import type { D1Database } from "@cloudflare/workers-types";
 import { vi } from "vitest";
 
 const defaultFetchResponse = {

--- a/api/tests/unit/repositories/batch-label.test.ts
+++ b/api/tests/unit/repositories/batch-label.test.ts
@@ -1,4 +1,3 @@
-import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ArticleLabelRepository } from "../../../src/repositories/articleLabel";
 import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
@@ -39,7 +38,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 				all: vi.fn(),
 				get: vi.fn(),
 			};
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			repository = new ArticleLabelRepository(mockDb as any);
 		});
 
@@ -55,7 +54,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 			];
 
 			// Mock Drizzle calls
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			const mockedDb = (repository as any).db;
 			mockedDb.insert.mockReturnThis();
 			mockedDb.values.mockReturnThis();
@@ -80,7 +79,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 				all: vi.fn(),
 				get: vi.fn(),
 			};
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			repository = new ArticleLabelRepository(mockDb as any);
 		});
 
@@ -89,7 +88,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 			const existingLabels = [{ articleId: 1 }, { articleId: 3 }];
 
 			// Mock Drizzle calls
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			const mockedDb = (repository as any).db;
 			mockedDb.select.mockReturnThis();
 			mockedDb.from.mockReturnThis();
@@ -113,7 +112,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 				all: vi.fn(),
 				get: vi.fn(),
 			};
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			repository = new DrizzleBookmarkRepository(mockDb as any);
 		});
 
@@ -155,7 +154,7 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 			];
 
 			// Mock Drizzle calls
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用モックオブジェクト
 			const mockedDb = (repository as any).db;
 			mockedDb.select.mockReturnThis();
 			mockedDb.from.mockReturnThis();

--- a/api/tests/unit/repositories/bookmark.test.ts
+++ b/api/tests/unit/repositories/bookmark.test.ts
@@ -1,11 +1,11 @@
-import { eq, inArray, isNull } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	type Bookmark,
-	type Label,
 	articleLabels,
+	type Bookmark,
 	bookmarks,
 	favorites,
+	type Label,
 	labels,
 } from "../../../src/db/schema";
 import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";

--- a/api/tests/unit/repositories/readStatus.test.ts
+++ b/api/tests/unit/repositories/readStatus.test.ts
@@ -1,12 +1,4 @@
-import { desc, eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/d1";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	articleLabels,
-	bookmarks,
-	favorites,
-	labels,
-} from "../../../src/db/schema";
 import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
 
 const mockAll = vi.fn();

--- a/api/tests/unit/repositories/unratedBookmarks.test.ts
+++ b/api/tests/unit/repositories/unratedBookmarks.test.ts
@@ -1,18 +1,16 @@
-import { eq, isNull } from "drizzle-orm";
+import { isNull } from "drizzle-orm";
 /**
  * 未評価ブックマーク取得機能のリポジトリ層テスト
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	type Bookmark,
-	type Label,
-	articleLabels,
 	articleRatings,
+	type Bookmark,
 	bookmarks,
 	favorites,
+	type Label,
 	labels,
 } from "../../../src/db/schema";
-import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";
 import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
 
 const mockDbClient = {

--- a/api/tests/unit/routes/bookmarks.test.ts
+++ b/api/tests/unit/routes/bookmarks.test.ts
@@ -7,15 +7,6 @@ import type { IBookmarkService } from "../../../src/interfaces/service/bookmark"
 import type { ILabelService } from "../../../src/interfaces/service/label";
 import { createBookmarksRouter } from "../../../src/routes/bookmarks";
 
-interface PaginationResponse {
-	success: boolean;
-	bookmarks: BookmarkWithLabel[];
-	pagination: {
-		currentPage: number;
-		totalPages: number;
-		totalItems: number;
-	};
-}
 
 const mockGetUnreadBookmarks = vi.fn();
 const mockGetUnreadBookmarksCount = vi.fn();

--- a/api/tests/unit/routes/dev.test.ts
+++ b/api/tests/unit/routes/dev.test.ts
@@ -1,8 +1,8 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import type { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createApp } from "../../../src/index";
 import type { Env } from "../../../src/index";
+import { createApp } from "../../../src/index";
 
 // モックの設定
 vi.mock("../../../src/workers/rssBatch", () => ({

--- a/api/tests/unit/routes/labels.test.ts
+++ b/api/tests/unit/routes/labels.test.ts
@@ -15,7 +15,7 @@ function compareObjectsIgnoringDateFormat(
 ): void {
 	// オブジェクトのすべてのプロパティに対して検証
 	for (const key in expected) {
-		if (Object.prototype.hasOwnProperty.call(expected, key)) {
+		if (Object.hasOwn(expected, key)) {
 			// プロパティの値が存在するか確認
 			expect(actual).toHaveProperty(key);
 

--- a/api/tests/unit/services/label.test.ts
+++ b/api/tests/unit/services/label.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Bookmark, Label } from "../../../src/db/schema";
+import type { Label } from "../../../src/db/schema";
 import type { IArticleLabelRepository } from "../../../src/interfaces/repository/articleLabel";
-import type { IBookmarkRepository } from "../../../src/interfaces/repository/bookmark";
-import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";
+import type {
+	BookmarkWithLabel,
+	IBookmarkRepository,
+} from "../../../src/interfaces/repository/bookmark";
 import type { ILabelRepository } from "../../../src/interfaces/repository/label";
 import { LabelService } from "../../../src/services/label";
 

--- a/api/tests/unit/services/readStatus.test.ts
+++ b/api/tests/unit/services/readStatus.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
 import { DefaultBookmarkService } from "../../../src/services/bookmark";
 
 vi.mock("../../../src/repositories/bookmark");

--- a/api/tests/unit/services/rssParser.test.ts
+++ b/api/tests/unit/services/rssParser.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { RSSParser } from "../../../src/services/rssParser";
-import type { Article } from "../../../src/types/rss";
 
 describe("RSSParser", () => {
 	let rssParser: RSSParser;

--- a/extension/background.js
+++ b/extension/background.js
@@ -29,7 +29,7 @@ async function sendUrlsToApi(urlData) {
 }
 
 // メッセージリスナーの設定
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
 	if (request.action === "collectAndSendUrls") {
 		// 選択されたタブの情報を使用
 		sendUrlsToApi(request.tabs)

--- a/extension/biome.json
+++ b/extension/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,19 +7,29 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": []
+		"includes": ["**"]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
 		}
 	},
 	"javascript": {

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -8,17 +8,16 @@
 			"name": "ext-yomimono",
 			"version": "1.0.0",
 			"devDependencies": {
-				"@biomejs/biome": "1.9.4",
+				"@biomejs/biome": "2.0.5",
 				"@types/node": "^22.15.30",
 				"typescript": "^5.8.3"
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.5.tgz",
+			"integrity": "sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -31,20 +30,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.0.5",
+				"@biomejs/cli-darwin-x64": "2.0.5",
+				"@biomejs/cli-linux-arm64": "2.0.5",
+				"@biomejs/cli-linux-arm64-musl": "2.0.5",
+				"@biomejs/cli-linux-x64": "2.0.5",
+				"@biomejs/cli-linux-x64-musl": "2.0.5",
+				"@biomejs/cli-win32-arm64": "2.0.5",
+				"@biomejs/cli-win32-x64": "2.0.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.5.tgz",
+			"integrity": "sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==",
 			"cpu": [
 				"arm64"
 			],
@@ -59,9 +58,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+			"integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
 			"cpu": [
 				"x64"
 			],
@@ -76,9 +75,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+			"integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -93,9 +92,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+			"integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
 			"cpu": [
 				"arm64"
 			],
@@ -110,9 +109,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+			"integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
 			"cpu": [
 				"x64"
 			],
@@ -127,9 +126,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+			"integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
 			"cpu": [
 				"x64"
 			],
@@ -144,9 +143,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+			"integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -161,9 +160,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+			"integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
 			"cpu": [
 				"x64"
 			],

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,7 +9,7 @@
 	},
 	"private": true,
 	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
+		"@biomejs/biome": "2.0.5",
 		"@types/node": "^22.15.30",
 		"typescript": "^5.8.3"
 	}

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -1,7 +1,8 @@
 body {
 	width: 400px;
 	padding: 16px;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-family:
+		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 .container {

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,23 +7,22 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": [
-			".next",
-			".open-next",
-			".wrangler",
-			"coverage",
-			"node_modules",
-			"*.json",
-			"*.mjs"
+		"includes": [
+			"**",
+			"!**/.next",
+			"!**/.open-next",
+			"!**/.wrangler",
+			"!**/coverage",
+			"!**/node_modules",
+			"!**/*.json",
+			"!**/*.mjs"
 		]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -35,6 +34,18 @@
 			"suspicious": {
 				"noArrayIndexKey": "off",
 				"noConfusingVoidType": "off"
+			},
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
 			}
 		}
 	},

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
 				"zod": "^3.25.48"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^1.9.4",
+				"@biomejs/biome": "2.0.5",
 				"@cloudflare/workers-types": "^4.20250607.0",
 				"@opennextjs/cloudflare": "1.2.1",
 				"@tailwindcss/postcss": "^4.1.8",
@@ -8410,11 +8410,10 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.5.tgz",
+			"integrity": "sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -8427,20 +8426,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.0.5",
+				"@biomejs/cli-darwin-x64": "2.0.5",
+				"@biomejs/cli-linux-arm64": "2.0.5",
+				"@biomejs/cli-linux-arm64-musl": "2.0.5",
+				"@biomejs/cli-linux-x64": "2.0.5",
+				"@biomejs/cli-linux-x64-musl": "2.0.5",
+				"@biomejs/cli-win32-arm64": "2.0.5",
+				"@biomejs/cli-win32-x64": "2.0.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.5.tgz",
+			"integrity": "sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==",
 			"cpu": [
 				"arm64"
 			],
@@ -8455,9 +8454,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+			"integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
 			"cpu": [
 				"x64"
 			],
@@ -8472,9 +8471,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+			"integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -8489,9 +8488,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+			"integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
 			"cpu": [
 				"arm64"
 			],
@@ -8506,9 +8505,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+			"integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
 			"cpu": [
 				"x64"
 			],
@@ -8523,9 +8522,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+			"integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
 			"cpu": [
 				"x64"
 			],
@@ -8540,9 +8539,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+			"integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -8557,9 +8556,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+			"integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
 			"cpu": [
 				"x64"
 			],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
 		"zod": "^3.25.48"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
+		"@biomejs/biome": "2.0.5",
 		"@cloudflare/workers-types": "^4.20250607.0",
 		"@opennextjs/cloudflare": "1.2.1",
 		"@tailwindcss/postcss": "^4.1.8",

--- a/frontend/src/app/favorites/page.tsx
+++ b/frontend/src/app/favorites/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { BookmarksList } from "@/features/bookmarks/components/BookmarksList";
 import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import { API_BASE_URL } from "@/lib/api/config";
-import { useQuery } from "@tanstack/react-query";
 
 // APIレスポンスの型定義
 interface FavoritesApiResponse {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { BookmarksList } from "@/features/bookmarks/components/BookmarksList";
 import { CreateBookmarkModal } from "@/features/bookmarks/components/CreateBookmarkModal";
 import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import { LabelFilter } from "@/features/labels/components/LabelFilter";
 import { useLabels } from "@/features/labels/hooks/useLabels";
 import { API_BASE_URL } from "@/lib/api/config";
-import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
 
 interface BookmarksApiResponse {
 	success: boolean;

--- a/frontend/src/app/ratings/page.tsx
+++ b/frontend/src/app/ratings/page.tsx
@@ -3,6 +3,7 @@
  */
 "use client";
 
+import { useState } from "react";
 import { Header } from "@/components/Header";
 import { MCPEvaluationGuide } from "@/features/ratings/components/MCPEvaluationGuide";
 import { RatingFilters } from "@/features/ratings/components/RatingFilters";
@@ -11,7 +12,6 @@ import { RatingsList } from "@/features/ratings/components/RatingsList";
 import { useRatingStats } from "@/features/ratings/queries/useRatingStats";
 import { useRatings } from "@/features/ratings/queries/useRatings";
 import type { RatingFilters as RatingFiltersType } from "@/features/ratings/types";
-import { useState } from "react";
 
 export default function RatingsPage() {
 	const [filters, setFilters] = useState<RatingFiltersType>({

--- a/frontend/src/app/recent/page.test.tsx
+++ b/frontend/src/app/recent/page.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import RecentPage from "./page";
 
@@ -7,7 +7,9 @@ import RecentPage from "./page";
 vi.mock("@/features/bookmarks/components/BookmarkCard", () => ({
 	BookmarkCard: ({
 		bookmark,
-	}: { bookmark: { id: number; title: string; url: string } }) => (
+	}: {
+		bookmark: { id: number; title: string; url: string };
+	}) => (
 		<div data-testid={`bookmark-card-${bookmark.id}`}>
 			<h3>{bookmark.title}</h3>
 			<p>{bookmark.url}</p>

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { useState } from "react";
 import { useMarkBookmarkAsRead } from "@/features/bookmarks/queries/useMarkBookmarkAsRead";
 import { useMarkBookmarkAsUnread } from "@/features/bookmarks/queries/useMarkBookmarkAsUnread";
 import { useToggleFavoriteBookmark } from "@/features/bookmarks/queries/useToggleFavoriteBookmark";
@@ -7,8 +9,6 @@ import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import { LabelDisplay } from "@/features/labels/components/LabelDisplay";
 import { StarRating } from "@/features/ratings/components/StarRating";
 import { useArticleRating } from "@/features/ratings/queries/useArticleRating";
-import Link from "next/link";
-import { useState } from "react";
 
 interface Props {
 	bookmark: BookmarkWithLabel;

--- a/frontend/src/features/bookmarks/components/CreateBookmarkModal.test.tsx
+++ b/frontend/src/features/bookmarks/components/CreateBookmarkModal.test.tsx
@@ -63,7 +63,9 @@ const createWrapper = () => {
 describe("CreateBookmarkModal", () => {
 	let wrapper: ({
 		children,
-	}: { children: React.ReactNode }) => React.ReactElement;
+	}: {
+		children: React.ReactNode;
+	}) => React.ReactElement;
 	const mockOnClose = vi.fn();
 
 	beforeEach(() => {
@@ -127,7 +129,7 @@ describe("CreateBookmarkModal", () => {
 
 	describe("バリデーション", () => {
 		it("タイトルが空の場合はエラーメッセージが表示される", async () => {
-			const user = userEvent.setup();
+			const _user = userEvent.setup();
 			render(<CreateBookmarkModal isOpen={true} onClose={mockOnClose} />, {
 				wrapper,
 			});
@@ -224,7 +226,7 @@ describe("CreateBookmarkModal", () => {
 			const user = userEvent.setup();
 
 			// 成功時のコールバックを実行するモック
-			const mockCreateBookmarkSuccess = vi.fn((data, callbacks) => {
+			const mockCreateBookmarkSuccess = vi.fn((_data, callbacks) => {
 				callbacks.onSuccess();
 			});
 
@@ -263,7 +265,7 @@ describe("CreateBookmarkModal", () => {
 
 			// エラー時のコールバックを実行するモック
 			const mockError = new Error("作成失敗");
-			const mockCreateBookmarkError = vi.fn((data, callbacks) => {
+			const mockCreateBookmarkError = vi.fn((_data, callbacks) => {
 				callbacks.onError(mockError);
 			});
 

--- a/frontend/src/features/bookmarks/components/CreateBookmarkModal.tsx
+++ b/frontend/src/features/bookmarks/components/CreateBookmarkModal.tsx
@@ -1,7 +1,7 @@
-import { Modal } from "@/components/Modal";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { Modal } from "@/components/Modal";
 import { useCreateBookmark } from "../queries/useCreateBookmark";
 
 const bookmarkSchema = z.object({

--- a/frontend/src/features/bookmarks/queries/useMarkBookmarkAsRead.ts
+++ b/frontend/src/features/bookmarks/queries/useMarkBookmarkAsRead.ts
@@ -2,10 +2,11 @@
  * ブックマークを既読にするフック
  * 楽観的更新により、サーバーへのリクエスト前にキャッシュを即座に更新する
  */
-import type { BookmarkWithLabel } from "@/features/bookmarks/types";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { markBookmarkAsRead } from "./api";
+import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import type { BookmarksData } from "./api";
+import { markBookmarkAsRead } from "./api";
 import { bookmarkKeys } from "./queryKeys";
 
 export const useMarkBookmarkAsRead = () => {

--- a/frontend/src/features/bookmarks/queries/useMarkBookmarkAsUnread.ts
+++ b/frontend/src/features/bookmarks/queries/useMarkBookmarkAsUnread.ts
@@ -2,10 +2,11 @@
  * ブックマークを未読にするフック
  * 楽観的更新により、サーバーへのリクエスト前にキャッシュを即座に更新する
  */
-import type { BookmarkWithLabel } from "@/features/bookmarks/types";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { markBookmarkAsUnread } from "./api";
+import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 import type { BookmarksData } from "./api";
+import { markBookmarkAsUnread } from "./api";
 import { bookmarkKeys } from "./queryKeys";
 
 export const useMarkBookmarkAsUnread = () => {

--- a/frontend/src/features/bookmarks/queries/useToggleFavoriteBookmark.ts
+++ b/frontend/src/features/bookmarks/queries/useToggleFavoriteBookmark.ts
@@ -2,10 +2,11 @@
  * ブックマークのお気に入り状態をトグルするフック
  * お気に入りに追加または削除を行い、楽観的更新でキャッシュを即座に更新する
  */
-import type { Bookmark } from "@/features/bookmarks/types";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { addBookmarkToFavorites, removeBookmarkFromFavorites } from "./api";
+import type { Bookmark } from "@/features/bookmarks/types";
 import type { BookmarksData } from "./api";
+import { addBookmarkToFavorites, removeBookmarkFromFavorites } from "./api";
 import { bookmarkKeys } from "./queryKeys";
 
 interface ToggleFavoriteVariables {

--- a/frontend/src/features/feeds/components/CreateFeedModal.test.tsx
+++ b/frontend/src/features/feeds/components/CreateFeedModal.test.tsx
@@ -176,7 +176,7 @@ describe("CreateFeedModal", () => {
 		const onCloseMock = vi.fn();
 		let successCallback: (() => void) | undefined;
 
-		mockMutate.mockImplementation((data, options) => {
+		mockMutate.mockImplementation((_data, options) => {
 			successCallback = options.onSuccess;
 		});
 
@@ -218,7 +218,7 @@ describe("CreateFeedModal", () => {
 	it("送信エラー時にエラーメッセージを表示する", async () => {
 		let errorCallback: ((error: Error) => void) | undefined;
 
-		mockMutate.mockImplementation((data, options) => {
+		mockMutate.mockImplementation((_data, options) => {
 			errorCallback = options.onError;
 		});
 

--- a/frontend/src/features/feeds/components/CreateFeedModal.tsx
+++ b/frontend/src/features/feeds/components/CreateFeedModal.tsx
@@ -1,5 +1,5 @@
-import { Modal } from "@/components/Modal";
 import { type FormEvent, useState } from "react";
+import { Modal } from "@/components/Modal";
 import { useCreateRSSFeed } from "../queries/useCreateRSSFeed";
 import type { CreateRSSFeedDTO } from "../types";
 

--- a/frontend/src/features/feeds/components/EditFeedModal.test.tsx
+++ b/frontend/src/features/feeds/components/EditFeedModal.test.tsx
@@ -170,7 +170,7 @@ describe("EditFeedModal", () => {
 		const onCloseMock = vi.fn();
 		let successCallback: (() => void) | undefined;
 
-		mockMutate.mockImplementation((data, options) => {
+		mockMutate.mockImplementation((_data, options) => {
 			successCallback = options.onSuccess;
 		});
 

--- a/frontend/src/features/feeds/components/EditFeedModal.tsx
+++ b/frontend/src/features/feeds/components/EditFeedModal.tsx
@@ -1,6 +1,6 @@
+import { type FormEvent, useState } from "react";
 import { Button } from "@/components/Button";
 import { Modal } from "@/components/Modal";
-import { type FormEvent, useState } from "react";
 import { useUpdateRSSFeed } from "../queries/useRSSFeeds";
 import type { RSSFeed } from "../types";
 

--- a/frontend/src/features/feeds/components/FeedCard.test.tsx
+++ b/frontend/src/features/feeds/components/FeedCard.test.tsx
@@ -64,7 +64,11 @@ vi.mock("./EditFeedModal", () => ({
 		feed,
 		isOpen,
 		onClose,
-	}: { feed: { name: string }; isOpen: boolean; onClose: () => void }) =>
+	}: {
+		feed: { name: string };
+		isOpen: boolean;
+		onClose: () => void;
+	}) =>
 		isOpen ? (
 			<div data-testid="edit-modal">
 				<p>編集モーダル: {feed.name}</p>
@@ -237,7 +241,7 @@ describe("FeedCard", () => {
 	it("削除成功時に確認ダイアログが閉じる", () => {
 		let successCallback: (() => void) | undefined;
 
-		mockMutate.mockImplementation((id, options) => {
+		mockMutate.mockImplementation((_id, options) => {
 			successCallback = options.onSuccess;
 		});
 

--- a/frontend/src/features/feeds/components/FeedCard.tsx
+++ b/frontend/src/features/feeds/components/FeedCard.tsx
@@ -1,6 +1,6 @@
+import { useState } from "react";
 import { Button } from "@/components/Button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { useState } from "react";
 import { useDeleteRSSFeed } from "../queries/useRSSFeeds";
 import type { RSSFeed } from "../types";
 import { EditFeedModal } from "./EditFeedModal";

--- a/frontend/src/features/feeds/pages/FeedListPage.test.tsx
+++ b/frontend/src/features/feeds/pages/FeedListPage.test.tsx
@@ -19,7 +19,10 @@ vi.mock("../components/CreateFeedModal", () => ({
 	CreateFeedModal: ({
 		isOpen,
 		onClose,
-	}: { isOpen: boolean; onClose: () => void }) =>
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+	}) =>
 		isOpen ? (
 			<div data-testid="create-feed-modal">
 				<button type="button" onClick={onClose}>

--- a/frontend/src/features/labels/components/LabelDeleteConfirm.test.tsx
+++ b/frontend/src/features/labels/components/LabelDeleteConfirm.test.tsx
@@ -2,7 +2,7 @@
  * LabelDeleteConfirm コンポーネントのテスト
  * ラベル削除確認モーダルの表示、操作、キーボードイベント、エラーハンドリングをテスト
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import type { Label } from "../types";

--- a/frontend/src/features/labels/hooks/useLabels.ts
+++ b/frontend/src/features/labels/hooks/useLabels.ts
@@ -1,6 +1,6 @@
-import { API_BASE_URL } from "@/lib/api/config";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import { API_BASE_URL } from "@/lib/api/config";
 import type { Label } from "../types";
 
 // APIレスポンスの型定義

--- a/frontend/src/features/labels/hooks/useManageLabels.ts
+++ b/frontend/src/features/labels/hooks/useManageLabels.ts
@@ -33,8 +33,10 @@ export function useManageLabels() {
 		mutationFn: ({
 			name,
 			description,
-		}: { name: string; description?: string }) =>
-			createLabel(name, description),
+		}: {
+			name: string;
+			description?: string;
+		}) => createLabel(name, description),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: labelKeys.lists() });
 			setIsCreateFormOpen(false);

--- a/frontend/src/features/labels/queries/api.ts
+++ b/frontend/src/features/labels/queries/api.ts
@@ -37,7 +37,7 @@ export const fetchLabels = async (): Promise<Label[]> => {
 };
 
 // 特定のラベルを取得する関数（現在は未使用）
-const fetchLabelById = async (id: number): Promise<Label> => {
+const _fetchLabelById = async (id: number): Promise<Label> => {
 	const response = await fetch(`${API_BASE_URL}/api/labels/${id}`);
 	if (!response.ok) {
 		throw new Error(`Failed to fetch label with ID: ${id}`);

--- a/frontend/src/features/ratings/components/RatingsList.test.tsx
+++ b/frontend/src/features/ratings/components/RatingsList.test.tsx
@@ -163,7 +163,7 @@ if (import.meta.vitest) {
 		// 空状態メッセージ
 		expect(screen.getByText("評価済み記事がありません")).toBeInTheDocument();
 		expect(
-			screen.getByText((content, element) => {
+			screen.getByText((_content, element) => {
 				return (
 					element?.textContent ===
 					"条件に一致する評価済み記事がありません。Claude (MCP) で記事を評価してください。"

--- a/frontend/src/features/ratings/queries/api.test.ts
+++ b/frontend/src/features/ratings/queries/api.test.ts
@@ -5,11 +5,9 @@ import { expect, test, vi } from "vitest";
 import type { CreateRatingData, RatingFilters } from "../types";
 import {
 	createRating,
-	deleteRating,
 	fetchArticleRating,
 	fetchRatingStats,
 	fetchRatings,
-	updateRating,
 } from "./api";
 
 if (import.meta.vitest) {

--- a/frontend/src/providers/QueryProvider.test.tsx
+++ b/frontend/src/providers/QueryProvider.test.tsx
@@ -4,7 +4,6 @@
  */
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import type React from "react";
 import { describe, expect, it } from "vitest";
 import { QueryProvider } from "./QueryProvider";
 
@@ -25,11 +24,11 @@ function TestComponent() {
 }
 
 // エラー境界用テスト：QueryProviderなしでuseQueryClientを使用
-function ComponentWithoutProvider() {
+function _ComponentWithoutProvider() {
 	try {
 		useQueryClient();
 		return <div data-testid="no-error">No error</div>;
-	} catch (error) {
+	} catch (_error) {
 		return <div data-testid="error">Error caught</div>;
 	}
 }

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -4,7 +4,7 @@
  */
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import { afterEach, beforeAll, vi } from "vitest";
 
 declare global {
 	namespace ImportMeta {

--- a/mcp/biome.json
+++ b/mcp/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,19 +7,29 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["node_modules", "coverage", "build"]
+		"includes": ["**", "!**/node_modules", "!**/coverage", "!**/build"]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": true
-	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
 		}
 	},
 	"javascript": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -12,7 +12,7 @@
 				"zod": "^3.25.56"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^1.9.4",
+				"@biomejs/biome": "2.0.5",
 				"@types/node": "^22.15.29",
 				"@vitest/coverage-v8": "^3.2.3",
 				"dotenv": "^16.5.0",
@@ -98,11 +98,10 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.5.tgz",
+			"integrity": "sha512-MztFGhE6cVjf3QmomWu83GpTFyWY8KIcskgRf2AqVEMSH4qI4rNdBLdpAQ11TNK9pUfLGz3IIOC1ZYwgBePtig==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -115,20 +114,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.0.5",
+				"@biomejs/cli-darwin-x64": "2.0.5",
+				"@biomejs/cli-linux-arm64": "2.0.5",
+				"@biomejs/cli-linux-arm64-musl": "2.0.5",
+				"@biomejs/cli-linux-x64": "2.0.5",
+				"@biomejs/cli-linux-x64-musl": "2.0.5",
+				"@biomejs/cli-win32-arm64": "2.0.5",
+				"@biomejs/cli-win32-x64": "2.0.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.5.tgz",
+			"integrity": "sha512-VIIWQv9Rcj9XresjCf3isBFfWjFStsdGZvm8SmwJzKs/22YQj167ge7DkxuaaZbNf2kmYif0AcjAKvtNedEoEw==",
 			"cpu": [
 				"arm64"
 			],
@@ -143,9 +142,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.5.tgz",
+			"integrity": "sha512-DRpGxBgf5Z7HUFcNUB6n66UiD4VlBlMpngNf32wPraxX8vYU6N9cb3xQWOXIQVBBQ64QfsSLJnjNu79i/LNmSg==",
 			"cpu": [
 				"x64"
 			],
@@ -160,9 +159,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.5.tgz",
+			"integrity": "sha512-FQTfDNMXOknf8+g9Eede2daaduRjTC2SNbfWPNFMadN9K3UKjeZ62jwiYxztPaz9zQQsZU8VbddQIaeQY5CmIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -177,9 +176,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.5.tgz",
+			"integrity": "sha512-OpflTCOw/ElEs7QZqN/HFaSViPHjAsAPxFJ22LhWUWvuJgcy/Z8+hRV0/3mk/ZRWy5A6fCDKHZqAxU+xB6W4mA==",
 			"cpu": [
 				"arm64"
 			],
@@ -194,9 +193,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.5.tgz",
+			"integrity": "sha512-znpfydUDPuDkyBTulnODrQVK2FaG/4hIOPcQSsF2GeauQOYrBAOplj0etGB0NUrr0dFsvaQ15nzDXYb60ACoiw==",
 			"cpu": [
 				"x64"
 			],
@@ -211,9 +210,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.5.tgz",
+			"integrity": "sha512-9lmjCnajAzpZXbav2P6D87ugkhnaDpJtDvOH5uQbY2RXeW6Rq18uOUltxgacGBP+d8GusTr+s3IFOu7SN0Ok8g==",
 			"cpu": [
 				"x64"
 			],
@@ -228,9 +227,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.5.tgz",
+			"integrity": "sha512-CP2wKQB+gh8HdJTFKYRFETqReAjxlcN9AlYDEoye8v2eQp+L9v+PUeDql/wsbaUhSsLR0sjj3PtbBtt+02AN3A==",
 			"cpu": [
 				"arm64"
 			],
@@ -245,9 +244,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.5.tgz",
+			"integrity": "sha512-Sw3rz2m6bBADeQpr3+MD7Ch4E1l15DTt/+dfqKnwkm3cn4BrYwnArmvKeZdVsFRDjMyjlKIP88bw1r7o+9aqzw==",
 			"cpu": [
 				"x64"
 			],

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"private": true,
 	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
+		"@biomejs/biome": "2.0.5",
 		"@types/node": "^22.15.29",
 		"@vitest/coverage-v8": "^3.2.3",
 		"dotenv": "^16.5.0",

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -87,21 +87,23 @@ export async function getUnlabeledArticles() {
 		);
 	}
 	const data = await response.json();
-	
+
 	// /api/bookmarks/unlabeledは基本的なBookmarkオブジェクトを返すため、
 	// labelプロパティを持たない。labelをnullとして追加する。
 	const UnlabeledArticlesResponseSchema = z.object({
 		success: z.literal(true),
-		bookmarks: z.array(z.object({
-			id: z.number(),
-			title: z.string(),
-			url: z.string(),
-			isRead: z.boolean(),
-			createdAt: z.string().or(z.instanceof(Date)),
-			updatedAt: z.string().or(z.instanceof(Date)),
-		})),
+		bookmarks: z.array(
+			z.object({
+				id: z.number(),
+				title: z.string(),
+				url: z.string(),
+				isRead: z.boolean(),
+				createdAt: z.string().or(z.instanceof(Date)),
+				updatedAt: z.string().or(z.instanceof(Date)),
+			}),
+		),
 	});
-	
+
 	const parsed = UnlabeledArticlesResponseSchema.safeParse(data);
 	if (!parsed.success) {
 		// Provide more context in the error message
@@ -110,7 +112,7 @@ export async function getUnlabeledArticles() {
 		);
 	}
 	// Extract data from 'bookmarks' key and add label: null for compatibility
-	return parsed.data.bookmarks.map(bookmark => ({
+	return parsed.data.bookmarks.map((bookmark) => ({
 		...bookmark,
 		label: null,
 		isFavorite: false, // デフォルト値を設定
@@ -497,21 +499,23 @@ export async function getBookmarkById(bookmarkId: number) {
 }
 
 // Schema for bookmark with read status
-const BookmarkWithReadStatusSchema = z.object({
-	id: z.number(),
-	url: z.string(),
-	title: z.string(),
-	labels: z.array(z.string()).optional(), // labelsを任意項目にする
-	isRead: z.boolean(),
-	isFavorite: z.boolean().optional(), // isFavoriteを任意項目にする（APIレスポンスに応じて）
-	createdAt: z.string(),
-	readAt: z.string().nullable().optional(), // readAtを任意項目にする
-	updatedAt: z.string().optional(), // updatedAtを追加（通常の未読ブックマークで必要）
-}).transform((data) => ({
-	...data,
-	labels: data.labels ?? [], // labelsがundefinedの場合は空配列を設定
-	isFavorite: data.isFavorite ?? false, // isFavoriteがundefinedの場合はfalseを設定
-}));
+const BookmarkWithReadStatusSchema = z
+	.object({
+		id: z.number(),
+		url: z.string(),
+		title: z.string(),
+		labels: z.array(z.string()).optional(), // labelsを任意項目にする
+		isRead: z.boolean(),
+		isFavorite: z.boolean().optional(), // isFavoriteを任意項目にする（APIレスポンスに応じて）
+		createdAt: z.string(),
+		readAt: z.string().nullable().optional(), // readAtを任意項目にする
+		updatedAt: z.string().optional(), // updatedAtを追加（通常の未読ブックマークで必要）
+	})
+	.transform((data) => ({
+		...data,
+		labels: data.labels ?? [], // labelsがundefinedの場合は空配列を設定
+		isFavorite: data.isFavorite ?? false, // isFavoriteがundefinedの場合はfalseを設定
+	}));
 
 // Schema for bookmarks list response
 const BookmarksListResponseSchema = z.object({
@@ -577,9 +581,15 @@ export async function getUnreadBookmarks() {
 		labels: bookmark.label ? [bookmark.label.name] : [],
 		isRead: bookmark.isRead,
 		isFavorite: bookmark.isFavorite ?? false,
-		createdAt: typeof bookmark.createdAt === 'string' ? bookmark.createdAt : bookmark.createdAt.toISOString(),
+		createdAt:
+			typeof bookmark.createdAt === "string"
+				? bookmark.createdAt
+				: bookmark.createdAt.toISOString(),
 		readAt: null,
-		updatedAt: typeof bookmark.updatedAt === 'string' ? bookmark.updatedAt : bookmark.updatedAt.toISOString(),
+		updatedAt:
+			typeof bookmark.updatedAt === "string"
+				? bookmark.updatedAt
+				: bookmark.updatedAt.toISOString(),
 	}));
 	return bookmarksWithReadStatus;
 }

--- a/mcp/src/lib/articleContentFetcher.ts
+++ b/mcp/src/lib/articleContentFetcher.ts
@@ -228,7 +228,7 @@ function getExtractionStrategies(): ExtractionStrategy[] {
  */
 async function extractStructuredData(
 	page: Page,
-	url: string,
+	_url: string,
 ): Promise<ArticleContent | null> {
 	try {
 		// JSON-LDの取得
@@ -327,7 +327,7 @@ async function extractStructuredData(
  */
 async function extractSemanticElements(
 	page: Page,
-	url: string,
+	_url: string,
 ): Promise<ArticleContent | null> {
 	const selectors = [
 		"article",
@@ -448,11 +448,11 @@ async function extractWithSiteStrategy(
  */
 async function extractWithGenericSelectors(
 	page: Page,
-	url: string,
+	_url: string,
 ): Promise<ArticleContent | null> {
 	const selectors = ["body"];
 
-	for (const selector of selectors) {
+	for (const _selector of selectors) {
 		try {
 			const content = await extractMainContent(page);
 			if (!content || content.length < 100) continue;

--- a/mcp/src/test/apiClientAdvanced.test.ts
+++ b/mcp/src/test/apiClientAdvanced.test.ts
@@ -6,7 +6,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type CreateRatingData,
-	type UpdateRatingData,
 	createArticleRating,
 	deleteArticleRating,
 	getArticleRating,
@@ -14,6 +13,7 @@ import {
 	getUnreadArticlesByLabel,
 	getUnreadBookmarks,
 	markBookmarkAsRead,
+	type UpdateRatingData,
 	updateArticleRating,
 } from "../lib/apiClient.js";
 

--- a/mcp/src/test/apiClientCore.test.ts
+++ b/mcp/src/test/apiClientCore.test.ts
@@ -3,10 +3,9 @@
  */
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
-	type CreateRatingData,
-	type UpdateRatingData,
-	assignLabelToArticle,
 	assignLabelsToMultipleArticles,
+	assignLabelToArticle,
+	type CreateRatingData,
 	createArticleRating,
 	createLabel,
 	deleteLabel,
@@ -14,9 +13,9 @@ import {
 	getBookmarkById,
 	getLabelById,
 	getReadBookmarks,
-	getUnreadArticlesByLabel,
 	getUnreadBookmarks,
 	markBookmarkAsRead,
+	type UpdateRatingData,
 	updateArticleRating,
 	updateLabelDescription,
 } from "../lib/apiClient.js";

--- a/mcp/src/test/apiClientExtended.test.ts
+++ b/mcp/src/test/apiClientExtended.test.ts
@@ -3,8 +3,8 @@
  */
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
-	type GetRatingsOptions,
 	deleteArticleRating,
+	type GetRatingsOptions,
 	getArticleRatings,
 	getLabels,
 	getRatingStats,

--- a/mcp/src/test/apiClientSchemaValidation.test.ts
+++ b/mcp/src/test/apiClientSchemaValidation.test.ts
@@ -4,9 +4,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	getReadBookmarks,
 	getUnlabeledArticles,
 	getUnreadBookmarks,
-	getReadBookmarks,
 } from "../lib/apiClient";
 
 // グローバルfetchのモック
@@ -85,7 +85,7 @@ describe("APIクライアント - スキーマバリデーション", () => {
 			});
 
 			await expect(getUnlabeledArticles()).rejects.toThrow(
-				"Invalid API response for unlabeled articles"
+				"Invalid API response for unlabeled articles",
 			);
 		});
 	});

--- a/mcp/src/test/articleContentFetcherExtended.test.ts
+++ b/mcp/src/test/articleContentFetcherExtended.test.ts
@@ -2,15 +2,9 @@
  * articleContentFetcher.ts 拡張テスト - 30%カバレッジ達成用
  */
 
-import type { Browser, Page } from "playwright";
+import type { Page } from "playwright";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import {
-	type ArticleContent,
-	type ExtractionStrategy,
-	type SiteStrategy,
-	fetchArticleContent,
-	generateRatingPrompt,
-} from "../lib/articleContentFetcher.js";
+import type { SiteStrategy } from "../lib/articleContentFetcher.js";
 
 describe("ArticleContentFetcher 拡張カバレッジテスト", () => {
 	beforeEach(() => {

--- a/mcp/src/test/articleContentFetcherIntegration.test.ts
+++ b/mcp/src/test/articleContentFetcherIntegration.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // 実際の関数パターンを模倣したテスト
 describe("ArticleContentFetcher 統合カバレッジテスト", () => {
-	let mockPage: Partial<Page>;
+	let _mockPage: Partial<Page>;
 	let mockLocator: Partial<Locator>;
 
 	beforeEach(() => {
@@ -22,7 +22,7 @@ describe("ArticleContentFetcher 統合カバレッジテスト", () => {
 			last: vi.fn(),
 		};
 
-		mockPage = {
+		_mockPage = {
 			url: vi.fn(),
 			$: vi.fn(),
 			$$: vi.fn(),

--- a/mcp/src/test/articleContentFetcherMajorCoverage.test.ts
+++ b/mcp/src/test/articleContentFetcherMajorCoverage.test.ts
@@ -5,11 +5,11 @@
 
 import type { Page } from "playwright";
 import {
-	type MockedFunction,
 	beforeEach,
 	describe,
 	expect,
 	it,
+	type MockedFunction,
 	vi,
 } from "vitest";
 
@@ -43,7 +43,7 @@ describe("ArticleContentFetcher 重要未カバー部分テスト", () => {
 			};
 
 			// セレクター戦略のテスト
-			for (const [key, selector] of Object.entries(qiitaSelectors)) {
+			for (const [_key, selector] of Object.entries(qiitaSelectors)) {
 				// 少なくとも1つのQiita特有のクラスを含む
 				expect(selector).toMatch(/it-|p-items/);
 			}
@@ -83,7 +83,7 @@ describe("ArticleContentFetcher 重要未カバー部分テスト", () => {
 
 			// note特有のパターン
 			const notePatterns = {
-				urlPattern: /note\.com\/[^\/]+\/n\/[a-zA-Z0-9]+/,
+				urlPattern: /note\.com\/[^/]+\/n\/[a-zA-Z0-9]+/,
 				titleSelector: ".note-header__title, h1.o-noteContentText",
 				contentSelector: ".note-content, .o-noteContentText__body",
 				authorSelector: ".note-author, .o-userInfo__name",
@@ -108,7 +108,7 @@ describe("ArticleContentFetcher 重要未カバー部分テスト", () => {
 			};
 
 			// URL パターン検証
-			expect(mediumUrl).toMatch(/medium\.com\/@[^\/]+\//);
+			expect(mediumUrl).toMatch(/medium\.com\/@[^/]+\//);
 			expect(Object.keys(mediumSelectors)).toContain("claps"); // Medium特有
 		});
 
@@ -577,11 +577,11 @@ if (import.meta.vitest) {
 
 	test("URLパターンマッチング", () => {
 		const sitePatterns = {
-			qiita: /^https:\/\/qiita\.com\/[^\/]+\/items\/[a-f0-9]+$/,
-			zenn: /^https:\/\/zenn\.dev\/[^\/]+\/articles\/[a-zA-Z0-9_-]+$/,
-			note: /^https:\/\/note\.com\/[^\/]+\/n\/[a-zA-Z0-9]+$/,
-			medium: /^https:\/\/medium\.com\/@[^\/]+\/[^\/]+$/,
-			devTo: /^https:\/\/dev\.to\/[^\/]+\/[^\/]+-[a-zA-Z0-9]+$/,
+			qiita: /^https:\/\/qiita\.com\/[^/]+\/items\/[a-f0-9]+$/,
+			zenn: /^https:\/\/zenn\.dev\/[^/]+\/articles\/[a-zA-Z0-9_-]+$/,
+			note: /^https:\/\/note\.com\/[^/]+\/n\/[a-zA-Z0-9]+$/,
+			medium: /^https:\/\/medium\.com\/@[^/]+\/[^/]+$/,
+			devTo: /^https:\/\/dev\.to\/[^/]+\/[^/]+-[a-zA-Z0-9]+$/,
 		};
 
 		// パターンマッチングのテスト

--- a/mcp/src/test/coverageBoostTests.test.ts
+++ b/mcp/src/test/coverageBoostTests.test.ts
@@ -2,7 +2,7 @@
  * カバレッジ向上テスト - 30%目標達成用追加テスト
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 // articleContentFetcher.tsの内部関数をより詳しくテスト
 describe("カバレッジ向上テスト", () => {
@@ -100,7 +100,7 @@ describe("カバレッジ向上テスト", () => {
 			};
 
 			// 各プロンプトが文字列として定義されている
-			for (const [key, value] of Object.entries(evaluationPrompts)) {
+			for (const [_key, value] of Object.entries(evaluationPrompts)) {
 				expect(typeof value).toBe("string");
 				expect(value.length).toBeGreaterThan(0);
 			}

--- a/mcp/src/test/getUnratedArticles.test.ts
+++ b/mcp/src/test/getUnratedArticles.test.ts
@@ -3,8 +3,8 @@ import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
  * 未評価記事取得MCPツールのテスト
  */
 import { describe, expect, it, vi } from "vitest";
-import * as apiClient from "../lib/apiClient.js";
 import type { BookmarkWithLabel } from "../lib/apiClient.js";
+import * as apiClient from "../lib/apiClient.js";
 
 // apiClientのモック
 vi.mock("../lib/apiClient.js", () => ({

--- a/mcp/src/test/indexDirectServerTests.test.ts
+++ b/mcp/src/test/indexDirectServerTests.test.ts
@@ -6,11 +6,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import * as apiClient from "../lib/apiClient.js";
+import type { ArticleContent } from "../lib/articleContentFetcher.js";
 import {
 	fetchArticleContent,
 	generateRatingPrompt,
 } from "../lib/articleContentFetcher.js";
-import type { ArticleContent } from "../lib/articleContentFetcher.js";
 
 // モック設定
 vi.mock("../lib/apiClient.js");

--- a/mcp/src/test/indexInitializationCoverage.test.ts
+++ b/mcp/src/test/indexInitializationCoverage.test.ts
@@ -3,7 +3,7 @@
  * モジュールキャッシュ問題を回避したアプローチ
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 describe("index.ts 初期化・設定カバレッジテスト", () => {
@@ -28,7 +28,7 @@ describe("index.ts 初期化・設定カバレッジテスト", () => {
 				return { parsed: null };
 			};
 
-			const result = mockEnvConfig();
+			const _result = mockEnvConfig();
 			expect(process.env.NODE_ENV).toBeDefined();
 		});
 	});

--- a/mcp/src/test/indexMajorCoverage.test.ts
+++ b/mcp/src/test/indexMajorCoverage.test.ts
@@ -36,7 +36,7 @@ describe("index.ts 主要機能カバレッジ向上", () => {
 		try {
 			await import("../index.js");
 			expect(true).toBe(true); // インポート成功
-		} catch (error) {
+		} catch (_error) {
 			// テスト環境では接続エラーが予想される
 			expect(true).toBe(true);
 		}
@@ -84,7 +84,7 @@ describe("index.ts 主要機能カバレッジ向上", () => {
 		try {
 			await import("../index.js");
 			expect(true).toBe(true);
-		} catch (error) {
+		} catch (_error) {
 			expect(true).toBe(true);
 		}
 	});
@@ -100,7 +100,7 @@ describe("index.ts 主要機能カバレッジ向上", () => {
 		try {
 			await import("../index.js");
 			expect(true).toBe(true);
-		} catch (error) {
+		} catch (_error) {
 			expect(true).toBe(true);
 		}
 	});

--- a/mcp/src/test/indexRatingTools.test.ts
+++ b/mcp/src/test/indexRatingTools.test.ts
@@ -4,11 +4,11 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import * as apiClient from "../lib/apiClient.js";
+import type { ArticleContent } from "../lib/articleContentFetcher.js";
 import {
 	fetchArticleContent,
 	generateRatingPrompt,
 } from "../lib/articleContentFetcher.js";
-import type { ArticleContent } from "../lib/articleContentFetcher.js";
 
 vi.mock("../lib/apiClient.js", () => ({
 	createArticleRating: vi.fn(),
@@ -27,7 +27,11 @@ async function createRateArticleWithContentHandler() {
 		articleId,
 		url,
 		fetchContent,
-	}: { articleId: number; url: string; fetchContent: boolean }) => {
+	}: {
+		articleId: number;
+		url: string;
+		fetchContent: boolean;
+	}) => {
 		try {
 			let articleContent: ArticleContent | null = null;
 

--- a/mcp/src/test/indexSimpleCoverage.test.ts
+++ b/mcp/src/test/indexSimpleCoverage.test.ts
@@ -3,7 +3,7 @@
  * モジュールキャッシュ問題を回避した実装
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 describe("index.ts カバレッジ向上テスト", () => {

--- a/mcp/src/test/indexSpecificCoverage.test.ts
+++ b/mcp/src/test/indexSpecificCoverage.test.ts
@@ -3,7 +3,7 @@
  * 特に bulkRateArticles ツールの詳細なカバレッジ向上
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("index.ts 特定未カバー行テスト", () => {
 	describe("bulkRateArticles のエラーハンドリング", () => {

--- a/mcp/src/test/mcpServer.test.ts
+++ b/mcp/src/test/mcpServer.test.ts
@@ -1,4 +1,3 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 /**
  * MCPサーバーツールの包括的テスト
  * 記事評価ポイント機能の全ツールをテスト
@@ -71,11 +70,11 @@ function createMockMcpServer() {
 }
 
 describe("MCP評価ツール統合テスト", () => {
-	let mockServer: ReturnType<typeof createMockMcpServer>;
+	let _mockServer: ReturnType<typeof createMockMcpServer>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockServer = createMockMcpServer();
+		_mockServer = createMockMcpServer();
 
 		// 環境変数設定
 		process.env.API_BASE_URL = "https://api.example.com";

--- a/mcp/src/test/ratingApiClient.test.ts
+++ b/mcp/src/test/ratingApiClient.test.ts
@@ -4,12 +4,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type CreateRatingData,
-	type GetRatingsOptions,
-	type UpdateRatingData,
 	createArticleRating,
+	type GetRatingsOptions,
 	getArticleRating,
 	getArticleRatings,
 	getRatingStats,
+	type UpdateRatingData,
 	updateArticleRating,
 } from "../lib/apiClient.js";
 

--- a/mcp/src/test/ratingStatsAdvanced.test.ts
+++ b/mcp/src/test/ratingStatsAdvanced.test.ts
@@ -5,8 +5,8 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as apiClient from "../lib/apiClient.js";
 import type { RatingStats } from "../lib/apiClient.js";
+import * as apiClient from "../lib/apiClient.js";
 
 // モックの設定
 vi.mock("../lib/apiClient.js");


### PR DESCRIPTION
## 概要
Biome v2がリリースされたため、全ディレクトリでマイグレーションを実施しました。

## 変更内容
- **Biome v2.0.5へアップグレード**: 全ディレクトリ（api、extension、frontend、mcp）で実施
- **設定ファイルのマイグレーション**: `biome migrate --write` コマンドで自動変換
- **リントエラーの修正**: v2で厳格化されたルールに対応

## 技術的詳細
### 主要な設定変更
- `files.ignore` → `files.includes` への変更（除外パターンを `\!` プレフィックスで指定）
- `organizeImports` → `assist.actions.source.organizeImports` への移行
- style ルールのエラー設定を明示的に指定

### 修正した内容
- 未使用変数・インポートの削除
- インポート順序の整理
- biome-ignore コメントの修正

## テスト結果
- API: 324テスト全て成功
- Extension: リント・フォーマット通過
- Frontend: 一部のReact関連警告あり（アプリケーション動作に影響なし）
- MCP: 425テスト全て成功

## 関連PR
以下のDependabotによるPRをクローズしました：
- #735 (API)
- #734 (Extension)  
- #733 (Frontend)
- #726 (MCP)

## 確認事項
- [x] 全ディレクトリでのマイグレーション完了
- [x] テスト実行確認
- [x] DependabotのPRクローズ

Closes #738

🤖 Generated with [Claude Code](https://claude.ai/code)