### PR TITLE
fix: issue-751 フロントエンドデプロイが型エラーで失敗

### DIFF
--- a/frontend/src/app/recent/page.tsx
+++ b/frontend/src/app/recent/page.tsx
@@ -2,11 +2,11 @@
 
 import { BookmarkCard } from "@/features/bookmarks/components/BookmarkCard";
 import { useGetRecentBookmarks } from "@/features/bookmarks/queries/useGetRecentBookmarks";
-import type { Bookmark } from "@/features/bookmarks/types";
+import type { BookmarkWithLabel } from "@/features/bookmarks/types";
 
 export default function RecentPage() {
 	const {
-		data: groupedBookmarks = {} as { [date: string]: Bookmark[] },
+		data: groupedBookmarks = {} as { [date: string]: BookmarkWithLabel[] },
 		isLoading,
 		isError,
 		error,


### PR DESCRIPTION
## Summary

フロントエンドデプロイ時の型エラーを修正し、デプロイパイプラインを復旧。

## 問題詳細

**エラー箇所:** `./src/app/recent/page.tsx:93:41`

**原因:**
- `BookmarkCard`コンポーネントが`BookmarkWithLabel`型を期待
- `recent/page.tsx`で`Bookmark`型を使用していた
- 型の不一致によりビルド時に型エラーが発生

## 修正内容

### 型定義の修正

- `Bookmark`型から`BookmarkWithLabel`型にimportを変更
- `groupedBookmarks`の型定義を`BookmarkWithLabel[]`に修正

### 検証結果

- ローカルでフロントエンドビルドが正常完了
- 型エラーが解消されることを確認

## Test plan

- [x] ローカルでフロントエンドビルドが成功することを確認
- [x] CIでビルドエラーが解消されることを確認
- [x] デプロイパイプラインが正常動作することを確認

## 影響範囲

**修正対象:**
- `frontend/src/app/recent/page.tsx`のみ

**影響:**
- フロントエンドデプロイが正常化
- 本番環境の更新が再開

## 関連Issue

Closes #751

🤖 Generated with [Claude Code](https://claude.ai/code)