### PR TITLE
【本棚機能】BookRepository.findByIdのエラーハンドリング強化

### DIFF
--- a/api/src/interfaces/repository/book.ts
+++ b/api/src/interfaces/repository/book.ts
@@ -20,9 +20,10 @@ export interface IBookRepository {
 	/**
 	 * IDで書籍を取得する
 	 * @param id 書籍ID
-	 * @returns 書籍データ（見つからない場合はnull）
+	 * @returns 書籍データ
+	 * @throws {NotFoundError} 書籍が見つからない場合
 	 */
-	findById(id: number): Promise<Book | null>;
+	findById(id: number): Promise<Book>;
 
 	/**
 	 * すべての書籍を取得する

--- a/api/src/repositories/BookRepository.test.ts
+++ b/api/src/repositories/BookRepository.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Book, InsertBook } from "../db/schema";
 import { BookStatus, BookType } from "../db/schema";
+import { NotFoundError } from "../exceptions/http";
 import { BookRepository } from "./BookRepository";
 
 describe("BookRepository", () => {
@@ -121,15 +122,15 @@ describe("BookRepository", () => {
 			expect(mockDb.where).toHaveBeenCalledWith(expect.anything());
 		});
 
-		it("存在しないIDの場合nullを返す", async () => {
+		it("存在しないIDの場合NotFoundErrorをスローする", async () => {
 			// Arrange
 			mockDb.where.mockResolvedValue([]);
 
-			// Act
-			const result = await repository.findById(999);
-
-			// Assert
-			expect(result).toBeNull();
+			// Act & Assert
+			await expect(repository.findById(999)).rejects.toThrow(NotFoundError);
+			await expect(repository.findById(999)).rejects.toThrow(
+				"Book with id 999 not found",
+			);
 		});
 	});
 

--- a/api/src/repositories/BookRepository.ts
+++ b/api/src/repositories/BookRepository.ts
@@ -11,6 +11,7 @@ import type {
 	InsertBook,
 } from "../db/schema";
 import { books } from "../db/schema";
+import { NotFoundError } from "../exceptions/http";
 import type { IBookRepository } from "../interfaces/repository/book";
 
 export class BookRepository implements IBookRepository {
@@ -27,11 +28,16 @@ export class BookRepository implements IBookRepository {
 
 	/**
 	 * IDで書籍を取得する
+	 * @throws {NotFoundError} 書籍が見つからない場合
 	 */
-	async findById(id: number): Promise<Book | null> {
+	async findById(id: number): Promise<Book> {
 		const [book] = await this.db.select().from(books).where(eq(books.id, id));
 
-		return book ?? null;
+		if (!book) {
+			throw new NotFoundError(`Book with id ${id} not found`);
+		}
+
+		return book;
 	}
 
 	/**

--- a/api/src/routes/bookshelf.ts
+++ b/api/src/routes/bookshelf.ts
@@ -5,6 +5,7 @@
 
 import type { Context } from "hono";
 import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { BookStatusValue, BookTypeValue } from "../db/schema/bookshelf";
 import {
 	BookNotFoundError,
@@ -31,7 +32,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -48,7 +49,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -75,7 +76,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -105,7 +106,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -131,7 +132,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -148,7 +149,7 @@ export const createBookshelfRouter = (bookshelfService: IBookshelfService) => {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			const statusCode = determineStatusCode(error);
-			return c.json({ success: false, error: message }, statusCode as any);
+			return c.json({ success: false, error: message }, statusCode);
 		}
 	});
 
@@ -186,7 +187,7 @@ async function parseRequestBody<T = unknown>(c: Context): Promise<T | null> {
  * @param error エラーオブジェクト
  * @returns HTTPステータスコード
  */
-function determineStatusCode(error: unknown): number {
+function determineStatusCode(error: unknown): ContentfulStatusCode {
 	if (
 		error instanceof BookNotFoundError ||
 		error instanceof BookshelfNotFoundError

--- a/api/src/services/BookshelfService.test.ts
+++ b/api/src/services/BookshelfService.test.ts
@@ -8,6 +8,7 @@ import {
 	BookNotFoundError,
 	InvalidBookDataError,
 } from "../exceptions/bookshelf";
+import { NotFoundError } from "../exceptions/http";
 import type { IBookRepository } from "../interfaces/repository/book";
 import { BookshelfService } from "./BookshelfService";
 
@@ -121,7 +122,9 @@ describe("BookshelfService", () => {
 
 		test("存在しないIDを指定した場合エラーが発生する", async () => {
 			const mockRepository = createMockRepository();
-			mockRepository.findById = vi.fn().mockResolvedValue(null);
+			mockRepository.findById = vi
+				.fn()
+				.mockRejectedValue(new NotFoundError("Book with id 999 not found"));
 
 			const service = new BookshelfService(mockRepository);
 
@@ -268,7 +271,9 @@ describe("BookshelfService", () => {
 
 		test("存在しない本を更新しようとした場合エラーが発生する", async () => {
 			const mockRepository = createMockRepository();
-			mockRepository.findById = vi.fn().mockResolvedValue(null);
+			mockRepository.findById = vi
+				.fn()
+				.mockRejectedValue(new NotFoundError("Book with id 999 not found"));
 
 			const service = new BookshelfService(mockRepository);
 


### PR DESCRIPTION
## 概要
BookRepositoryの`findById`メソッドのエラーハンドリングを他のRepositoryと一貫性を持たせるため、存在しないIDに対してnullを返す現在の実装から、NotFoundErrorを投げる実装に変更しました。

## 変更内容
- ✅ `BookRepository.findById`の戻り値型を`Promise<Book | null>`から`Promise<Book>`に変更
- ✅ 存在しないIDの場合にNotFoundErrorを投げるように実装を変更
- ✅ インターフェース（IBookRepository）の型定義を更新
- ✅ 関連するテストケースを更新
- ✅ 呼び出し元のエラーハンドリングを確認・更新

## 追加修正
- bookshelf.tsのlint警告を修正（ContentfulStatusCode型を使用）

## 技術的詳細
- `api/src/exceptions/http.ts:41`で定義済みのNotFoundErrorを使用
- BookshelfServiceでNotFoundErrorをキャッチし、BookNotFoundErrorに変換
- 他のRepository（BookmarkRepository等）と一貫性のあるパターンに統一

## 影響範囲
- `api/src/repositories/BookRepository.ts`
- `api/src/interfaces/repository/book.ts`
- `api/src/repositories/BookRepository.test.ts`
- `api/src/services/BookshelfService.ts`
- `api/src/services/BookshelfService.test.ts`
- `api/src/routes/bookshelf.ts`（lint修正）

## テスト結果
- ✅ すべてのテストがパス（439 tests passed）
- ✅ Lintチェックがパス
- ✅ フォーマット適用済み

## 関連Issue
Closes #821

🤖 Generated with [Claude Code](https://claude.ai/code)