### PR TITLE
✅ test: 本棚機能テストのアサーション改善 (#827)

### DIFF
--- a/api/tests/unit/routes/bookshelf.test.ts
+++ b/api/tests/unit/routes/bookshelf.test.ts
@@ -184,7 +184,7 @@ describe("本棚APIエンドポイント", () => {
 
 			expect(response.status).toBe(400);
 			expect(json.success).toBe(false);
-			expect(json.error).toContain("Invalid ID");
+			expect(json.error).toBe("Invalid ID");
 		});
 	});
 
@@ -259,7 +259,7 @@ describe("本棚APIエンドポイント", () => {
 
 			expect(response.status).toBe(400);
 			expect(json.success).toBe(false);
-			expect(json.error).toContain("title");
+			expect(json.error).toBe("title is required");
 		});
 	});
 


### PR DESCRIPTION
## 概要
本棚機能のテストにおいて、エラーメッセージのアサーションを部分文字列マッチング（`toContain`）から完全一致（`toBe`）に変更しました。

## 変更内容
- `api/tests/unit/routes/bookshelf.test.ts`のエラーアサーションを改善
  - 183行目: `expect(json.error).toContain("Invalid ID")` → `expect(json.error).toBe("Invalid ID")`
  - 262行目: `expect(json.error).toContain("title")` → `expect(json.error).toBe("title is required")`

## なぜこの変更が必要か
- より厳密なテストアサーションによりAPIのエラーメッセージが意図通りであることを保証
- テストの信頼性向上
- 将来的なエラーメッセージの意図しない変更を検知可能に

## 動作確認
- [x] テストがパスすることを確認 (`pnpm run test`)
- [x] リントチェックがパスすることを確認 (`pnpm run lint`)

## Issueリンク
Fixes #827

## レビューポイント
- エラーメッセージの完全一致による影響がないか
- 他に同様の改善が必要な箇所がないか

🤖 Generated with [Claude Code](https://claude.ai/code)