### PR TITLE
【本棚機能】エラークラスにHTTPステータスコードを統合して拡張性を向上

### DIFF
--- a/api/src/exceptions/bookshelf.ts
+++ b/api/src/exceptions/bookshelf.ts
@@ -1,47 +1,50 @@
 /**
  * 本棚機能に関するカスタムエラークラス
  */
+import { BaseError, HttpError } from "./base";
 
-export class BookshelfNotFoundError extends Error {
+export class BookshelfNotFoundError extends HttpError {
 	constructor(id: number) {
-		super(`Bookshelf with id ${id} not found`);
+		super(`Bookshelf with id ${id} not found`, 404);
 		this.name = "BookshelfNotFoundError";
 	}
 }
 
-export class BookNotFoundError extends Error {
+export class BookNotFoundError extends HttpError {
 	constructor();
 	constructor(id: number);
 	constructor(bookshelfId: number, bookId: number);
 	constructor(idOrBookshelfId?: number, bookId?: number) {
+		let message: string;
 		if (idOrBookshelfId === undefined) {
-			super("Book not found");
+			message = "Book not found";
 		} else if (bookId !== undefined) {
-			super(`Book with id ${bookId} not found in bookshelf ${idOrBookshelfId}`);
+			message = `Book with id ${bookId} not found in bookshelf ${idOrBookshelfId}`;
 		} else {
-			super(`Book with id ${idOrBookshelfId} not found`);
+			message = `Book with id ${idOrBookshelfId} not found`;
 		}
+		super(message, 404);
 		this.name = "BookNotFoundError";
 	}
 }
 
-export class InvalidBookshelfDataError extends Error {
+export class InvalidBookshelfDataError extends HttpError {
 	constructor(message: string) {
-		super(message);
+		super(message, 400);
 		this.name = "InvalidBookshelfDataError";
 	}
 }
 
-export class InvalidBookDataError extends Error {
+export class InvalidBookDataError extends HttpError {
 	constructor(message: string) {
-		super(message);
+		super(message, 400);
 		this.name = "InvalidBookDataError";
 	}
 }
 
-export class BookshelfOperationError extends Error {
+export class BookshelfOperationError extends BaseError {
 	constructor(message: string) {
-		super(message);
+		super(message, 500, true);
 		this.name = "BookshelfOperationError";
 	}
 }
@@ -53,48 +56,62 @@ if (import.meta.vitest) {
 		const error = new BookshelfNotFoundError(1);
 		expect(error.message).toBe("Bookshelf with id 1 not found");
 		expect(error.name).toBe("BookshelfNotFoundError");
+		expect(error.statusCode).toBe(404);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("BookNotFoundError を正しく作成できる（ID不明）", () => {
 		const error = new BookNotFoundError();
 		expect(error.message).toBe("Book not found");
 		expect(error.name).toBe("BookNotFoundError");
+		expect(error.statusCode).toBe(404);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("BookNotFoundError を正しく作成できる（単一ID）", () => {
 		const error = new BookNotFoundError(2);
 		expect(error.message).toBe("Book with id 2 not found");
 		expect(error.name).toBe("BookNotFoundError");
+		expect(error.statusCode).toBe(404);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("BookNotFoundError を正しく作成できる（本棚IDと本ID）", () => {
 		const error = new BookNotFoundError(1, 2);
 		expect(error.message).toBe("Book with id 2 not found in bookshelf 1");
 		expect(error.name).toBe("BookNotFoundError");
+		expect(error.statusCode).toBe(404);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("InvalidBookshelfDataError を正しく作成できる", () => {
 		const error = new InvalidBookshelfDataError("Invalid name");
 		expect(error.message).toBe("Invalid name");
 		expect(error.name).toBe("InvalidBookshelfDataError");
+		expect(error.statusCode).toBe(400);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("InvalidBookDataError を正しく作成できる", () => {
 		const error = new InvalidBookDataError("URL is required");
 		expect(error.message).toBe("URL is required");
 		expect(error.name).toBe("InvalidBookDataError");
+		expect(error.statusCode).toBe(400);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 
 	test("BookshelfOperationError を正しく作成できる", () => {
 		const error = new BookshelfOperationError("Database error");
 		expect(error.message).toBe("Database error");
 		expect(error.name).toBe("BookshelfOperationError");
+		expect(error.statusCode).toBe(500);
 		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(BaseError);
 	});
 }


### PR DESCRIPTION
## 概要
Issue #833 の実装です。
PR #831 のレビューで指摘された改善点として、エラークラスにHTTPステータスコード情報を統合しました。

## 変更内容
### 1. エラークラスの継承構造の改善
- ✅ `BookshelfNotFoundError` と `BookNotFoundError` を `HttpError` から継承（404）
- ✅ `InvalidBookshelfDataError` と `InvalidBookDataError` を `HttpError` から継承（400）
- ✅ `BookshelfOperationError` を `BaseError` から継承（500）

### 2. determineStatusCode関数のシンプル化
Before:
```typescript
function determineStatusCode(error: unknown): ContentfulStatusCode {
  if (error instanceof BookNotFoundError || error instanceof BookshelfNotFoundError) {
    return 404;
  }
  if (error instanceof InvalidBookDataError || error instanceof InvalidBookshelfDataError || error instanceof BadRequestError) {
    return 400;
  }
  return 500;
}
```

After:
```typescript
function determineStatusCode(error: unknown): ContentfulStatusCode {
  if (error instanceof BaseError) {
    return error.statusCode as ContentfulStatusCode;
  }
  return 500;
}
```

### 3. テストケースの更新
- ✅ 各エラークラスの `statusCode` プロパティを検証
- ✅ 継承関係（`HttpError`、`BaseError`）を検証
- ✅ `determineStatusCode` 関数のユニットテストを追加

## 期待される効果
- ✨ 新しいエラークラス追加時に `determineStatusCode` の変更が不要
- 📝 エラークラスとHTTPステータスコードの関係が明確
- 🔧 保守性と拡張性の向上
- 🎯 Single Responsibility Principle（単一責任の原則）の遵守

## テスト結果
- ✅ 全443件のテストがパス
- ✅ リント警告は既存の `any` 型に関するもののみ（テストファイル内）

## 関連
- Fixes #833
- Related to PR #831
- Related to Issue #826, #832

🤖 Generated with [Claude Code](https://claude.ai/code)