### PR TITLE
🔍 test: エラーアサーションの精査と改善検討

### DIFF
--- a/api/tests/unit/routes/labels.test.ts
+++ b/api/tests/unit/routes/labels.test.ts
@@ -373,7 +373,9 @@ describe("Labels Route", () => {
 
 			expect(res.status).toBe(400);
 			expect(body.success).toBe(false);
-			expect(body.message).toContain("name is required");
+			expect(body.message).toBe(
+				"name is required and must be a non-empty string",
+			);
 			expect(mockCreateLabel).not.toHaveBeenCalled();
 		});
 
@@ -391,7 +393,9 @@ describe("Labels Route", () => {
 
 			expect(res.status).toBe(400);
 			expect(body.success).toBe(false);
-			expect(body.message).toContain("name is required");
+			expect(body.message).toBe(
+				"name is required and must be a non-empty string",
+			);
 			expect(mockCreateLabel).not.toHaveBeenCalled();
 		});
 


### PR DESCRIPTION
## 概要
PR #850 のレビューで指摘された、他のテストファイルにおける部分文字列マッチング（`toContain`）の使用箇所について精査し、必要に応じて改善を行いました。

## 変更内容
### 🔧 修正対象
1. **`api/tests/unit/routes/labels.test.ts:376,394`**
   - `toContain("name is required")` → `toBe("name is required and must be a non-empty string")`
   - 理由: エラーメッセージが固定文字列のため、完全一致検証が適切

### ✅ 維持対象
1. **`api/tests/unit/routes/batch-label.test.ts:189`**
   - `toContain("Invalid article ID")` を維持
   - 理由: 実際のメッセージは `"Invalid article ID: {value}"` で動的値を含むため

## 期待される効果
- ✅ テストの信頼性向上
- ✅ エラーメッセージの意図しない変更の検知
- ✅ 適切なアサーション手法の使い分け

## テスト結果
```bash
# 全テスト（443件）が正常にパス
pnpm run test --run
# ✓ 443 passed

# 修正対象のテストファイルも正常動作
pnpm run test tests/unit/routes/labels.test.ts
# ✓ 25 passed
```

## 関連
- Fixes #852
- 関連PR: #850

🤖 Generated with [Claude Code](https://claude.ai/code)