### PR TITLE
🔧 refactor: BookshelfService.assertBookExistsメソッドのエラーハンドリング改善

### DIFF
--- a/api/src/exceptions/bookshelf.ts
+++ b/api/src/exceptions/bookshelf.ts
@@ -55,6 +55,13 @@ export class BookshelfOperationError extends BaseError {
 	}
 }
 
+export class BookOperationError extends HttpError {
+	constructor(operation: string) {
+		super(`Book ${operation} failed: book not found`, 404);
+		this.name = "BookOperationError";
+	}
+}
+
 if (import.meta.vitest) {
 	const { test, expect } = import.meta.vitest;
 
@@ -128,5 +135,14 @@ if (import.meta.vitest) {
 		expect(error.statusCode).toBe(500);
 		expect(error).toBeInstanceOf(Error);
 		expect(error).toBeInstanceOf(BaseError);
+	});
+
+	test("BookOperationError を正しく作成できる", () => {
+		const error = new BookOperationError("update");
+		expect(error.message).toBe("Book update failed: book not found");
+		expect(error.name).toBe("BookOperationError");
+		expect(error.statusCode).toBe(404);
+		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(HttpError);
 	});
 }

--- a/api/src/services/BookshelfService.ts
+++ b/api/src/services/BookshelfService.ts
@@ -12,6 +12,7 @@ import type {
 import { BookStatus, BookType } from "../db/schema/bookshelf";
 import {
 	BookNotFoundError,
+	BookOperationError,
 	InvalidBookDataError,
 } from "../exceptions/bookshelf";
 import { NotFoundError } from "../exceptions/http";
@@ -155,7 +156,7 @@ export class BookshelfService implements IBookshelfService {
 		this.validateUrlRequirement(newType, newUrl);
 
 		const updatedBook = await this.bookRepository.update(id, data);
-		this.assertBookExists(updatedBook);
+		this.assertBookExists(updatedBook, "update");
 		return updatedBook;
 	}
 
@@ -174,7 +175,7 @@ export class BookshelfService implements IBookshelfService {
 				? await this.bookRepository.markAsCompleted(id)
 				: await this.bookRepository.updateStatus(id, status);
 
-		this.assertBookExists(book);
+		this.assertBookExists(book, "status update");
 		return book;
 	}
 
@@ -249,12 +250,15 @@ export class BookshelfService implements IBookshelfService {
 	/**
 	 * 本の存在確認（update/markAsCompletedの結果チェック用）
 	 * @param book チェック対象の本
-	 * @throws {BookNotFoundError} 本がnullの場合
+	 * @param operation 実行中の操作名
+	 * @throws {BookOperationError} 本がnullの場合
 	 */
-	private assertBookExists(book: Book | null): asserts book is Book {
+	private assertBookExists(
+		book: Book | null,
+		operation: string,
+	): asserts book is Book {
 		if (!book) {
-			// assertメソッドはIDが不明なため、汎用的なエラーメッセージを使用
-			throw new BookNotFoundError();
+			throw new BookOperationError(operation);
 		}
 	}
 


### PR DESCRIPTION
## 📋 概要
#856 で指摘されたBookshelfService.assertBookExistsメソッドのエラーハンドリングを改善しました。

## 🔧 変更内容
- [ ] `BookOperationError`クラスを新規作成し、操作名を含むエラーメッセージを出力するように変更
- [ ] `assertBookExists`メソッドに操作名パラメータを追加
- [ ] 更新操作（update、status update）で適切な操作名を渡すように修正
- [ ] 関連するテストケースを更新

## 📝 変更理由
### 問題点
- ID不明時に`BookNotFoundError(0)`を使用していた実装は直感的でなかった
- 他のメソッドとの一貫性に欠けていた

### 改善内容  
- 専用のエラークラス`BookOperationError`を作成
- 操作コンテキストを含むエラーメッセージによりデバッグが容易に
- エラーメッセージが`Book update failed: book not found`のようにより具体的に

## ✅ 動作確認
- [x] 全てのテストがパス（`pnpm run test`）
- [x] リントチェックがパス（`pnpm run lint`）
- [x] 新規エラークラスのテストを追加
- [x] 既存のテストを新しいエラークラスに対応

## 📌 関連Issue
Fixes #856

## 🔍 レビューポイント
- エラーメッセージの適切性
- テストカバレッジの十分性
- 他の同様のケースへの適用可能性

🤖 Generated with [Claude Code](https://claude.ai/code)