### PR TITLE
🔧 fix: Claude Code Reviewワークフローの自動実行トリガーを修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,16 +1,13 @@
 name: Claude Code Review
 
-# This workflow triggers when @claude is mentioned in PR comments
+# This workflow triggers on PR creation and updates
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   claude-review:
-    # Only run on PR comments (not issue comments) when @claude is mentioned
-    if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@claude')
+    # Run on all PR events
     
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 📋 概要
Claude Code ReviewワークフローがPRコメントではなく、PRの作成・更新時に自動実行されるように修正しました。

## 🔧 変更内容
### 変更前
- `issue_comment`イベントでトリガー
- コメントに`@claude`が含まれる場合のみ実行

### 変更後
- `pull_request`イベントでトリガー
- PRの以下のアクション時に自動実行：
  - `opened`: 新規PR作成時
  - `synchronize`: PR更新時（新しいコミットのプッシュ）
  - `reopened`: クローズされたPRの再オープン時

## 📝 変更理由
- **自動化**: PRごとに自動的にコードレビューが実行されるため、手動でコメントする必要がなくなります
- **効率化**: すべてのPRで一貫したレビューが保証されます
- **即時性**: PRの作成や更新と同時にレビューが開始されます

## ✅ 動作確認
- [x] YAML構文チェック完了（`npx yaml-lint`で検証済み）
- [ ] このPR自体でClaude Code Reviewが自動実行されることを確認

## 📌 関連Issue
Fixes #898

## ⚠️ 注意事項
このPRがマージされると、すべてのPRで自動的にClaude Code Reviewが実行されるようになります。
必要に応じて、特定の条件でスキップする設定（コメントアウトされている部分）の活用を検討してください。

🤖 Generated with [Claude Code](https://claude.ai/code)