### PR TITLE
🎯 issue #954: Remove unused X close button from Modal component

### DIFF
--- a/frontend/src/components/Modal.test.tsx
+++ b/frontend/src/components/Modal.test.tsx
@@ -29,21 +29,6 @@ describe("Modal", () => {
 		expect(screen.queryByText("モーダルコンテンツ")).not.toBeInTheDocument();
 	});
 
-	test("閉じるボタンクリックでonCloseが呼ばれる", () => {
-		const mockOnClose = vi.fn();
-
-		render(
-			<Modal isOpen={true} onClose={mockOnClose} title="テストモーダル">
-				<p>モーダルコンテンツ</p>
-			</Modal>,
-		);
-
-		const closeButton = screen.getByLabelText("閉じる");
-		fireEvent.click(closeButton);
-
-		expect(mockOnClose).toHaveBeenCalled();
-	});
-
 	test("オーバーレイクリックでonCloseが呼ばれる", () => {
 		const mockOnClose = vi.fn();
 
@@ -110,9 +95,6 @@ describe("Modal", () => {
 				<p>モーダルコンテンツ</p>
 			</Modal>,
 		);
-
-		const closeButton = screen.getByLabelText("閉じる");
-		expect(closeButton).toBeInTheDocument();
 
 		const overlayButton = screen.getByLabelText("モーダルを閉じる");
 		expect(overlayButton).toBeInTheDocument();

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -44,28 +44,6 @@ export function Modal({ isOpen, onClose, children, title }: ModalProps) {
 			<div className="relative bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
 				{title && <h2 className="text-xl font-bold mb-4">{title}</h2>}
 
-				{/* クローズボタン */}
-				<button
-					type="button"
-					onClick={onClose}
-					className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
-					aria-label="閉じる"
-				>
-					<svg
-						className="h-6 w-6"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							strokeWidth={2}
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
-				</button>
-
 				{children}
 			</div>
 		</div>


### PR DESCRIPTION
## 概要
モーダルコンポーネントの未使用のX（閉じるボタン）を削除しました。

## 変更内容
- `Modal.tsx`から以下を削除：
  - X（閉じる）ボタンのJSXコード
  - SVGアイコン実装
  
## 注記
ユーザーは依然として以下の方法でモーダルを閉じることができます：
- オーバーレイをクリック
- Escapeキーを押す

## テスト
- フロントエンド全テストが通過（443 tests passing）
- リント検査がクリア
- 関連するテストケースを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)