### PR TITLE
MCP除却：markBookmarkAsRead

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -15,7 +15,6 @@
 
 ### ブックマーク管理ツール
 - **`getUnreadBookmarks`**: 未読ブックマークを取得します。（引数なし）
-- **`markBookmarkAsRead`**: 指定ブックマークを既読にします。（引数: `bookmarkId`）
 
 ## Connecting with a Client
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -302,40 +302,6 @@ server.tool(
 	},
 );
 
-// 9. Tool to mark bookmark as read
-server.tool(
-	"markBookmarkAsRead",
-	{
-		bookmarkId: z.number().int().positive(),
-	},
-	async ({ bookmarkId }) => {
-		try {
-			const result = await apiClient.markBookmarkAsRead(bookmarkId);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `ブックマークID: ${bookmarkId}を既読にマークしました。\n${JSON.stringify(result, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(`Error in markBookmarkAsRead tool (bookmarkId: ${bookmarkId}):`, errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `ブックマークの既読マークに失敗しました: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
 // --- End Tool Definition ---
 
 async function main() {

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -342,12 +342,6 @@ export async function assignLabelsToMultipleArticles(
 	};
 }
 
-// Schema for mark as read response
-const MarkAsReadResponseSchema = z.object({
-	success: z.literal(true),
-	message: z.string(),
-});
-
 /**
  * 未読のブックマークを取得します
  * @returns 未読のブックマークのリスト
@@ -379,28 +373,6 @@ export async function getUnreadBookmarks() {
 	}));
 	return bookmarksWithReadStatus;
 }
-/**
- * ブックマークを既読にマークします
- * @param bookmarkId - ブックマークID
- * @returns 処理結果
- */
-export async function markBookmarkAsRead(bookmarkId: number) {
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks/${bookmarkId}/read`, {
-		method: "PATCH",
-	});
-
-	if (!response.ok) {
-		throw new Error(`Failed to mark bookmark ${bookmarkId} as read: ${response.statusText}`);
-	}
-
-	const data = await response.json();
-	const parsed = MarkAsReadResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response after marking bookmark as read: ${parsed.error.message}`);
-	}
-	return parsed.data;
-}
-
 /**
  * 未使用ラベルをクリーンアップします
  * @returns クリーンアップの結果


### PR DESCRIPTION
closes #970

## 目的
- MCPからmarkBookmarkAsReadツールを除却する

## 変更範囲
- mcp/src/index.ts
- mcp/src/lib/apiClient.ts
- mcp/README.md

## 動作確認
- pnpm -C mcp run typecheck