### PR TITLE
MCP除却：deleteLabel

### DIFF
--- a/docs/機能仕様/ラベリング機能/06_Claude連携.md
+++ b/docs/機能仕様/ラベリング機能/06_Claude連携.md
@@ -124,49 +124,6 @@ const result = await callTool("assignLabel", {
 });
 ```
 
-### 4. deleteLabel
-指定されたIDのラベルを削除します。
-
-```typescript
-const result = await callTool("deleteLabel", {
-  labelId: 1
-});
-```
-
-#### 引数
-- labelId: 削除するラベルのID（正の整数）
-
-#### 戻り値
-- 成功時:
-  ```json
-  {
-    "content": [
-      {
-        "type": "text",
-        "text": "Successfully deleted label ID 1."
-      }
-    ],
-    "isError": false
-  }
-  ```
-- エラー時:
-  ```json
-  {
-    "content": [
-      {
-        "type": "text",
-        "text": "Failed to delete label: [エラーメッセージ]"
-      }
-    ],
-    "isError": true
-  }
-  ```
-
-#### エラーケース
-1. 不正なラベルID（400 Bad Request）
-2. 存在しないラベル（404 Not Found）
-3. サーバーエラー（500 Internal Server Error）
-
 ## エラー処理
 
 ### 1. API通信エラー

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,7 +9,6 @@
 - **`getLabels`**: 既存のラベル一覧をAPIから取得します。（引数なし）
 - **`assignLabel`**: 指定された記事IDに指定されたラベル名をAPI経由で割り当てます。（引数: `articleId`, `labelName`, `description`）
 - **`getLabelById`**: 特定のラベルを取得します。（引数: `labelId`）
-- **`deleteLabel`**: ラベルを削除します。（引数: `labelId`）
 - **`updateLabelDescription`**: ラベルの説明を更新します。（引数: `labelId`, `description`）
 - **`assignLabelsToMultipleArticles`**: 複数の記事に一括でラベルを付与します。（引数: `articleIds`, `labelName`, `description`）
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -142,41 +142,7 @@ server.tool(
 	},
 );
 
-// 5. Tool to delete a label
-server.tool(
-	"deleteLabel",
-	{
-		labelId: z.number().int().positive(),
-	},
-	async ({ labelId }) => {
-		try {
-			await apiClient.deleteLabel(labelId);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Successfully deleted label ID ${labelId}.`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(`Error in deleteLabel tool (labelId: ${labelId}):`, errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Failed to delete label: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 6. Tool to update a label's description
+// 5. Tool to update a label's description
 server.tool(
 	"updateLabelDescription",
 	{

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -53,12 +53,6 @@ const UpdateLabelDescriptionResponseSchema = z.object({
 	label: LabelSchema,
 });
 
-// Schema for the DELETE /api/labels/:id response
-const DeleteLabelResponseSchema = z.object({
-	success: z.literal(true),
-	message: z.string(),
-});
-
 // Schema for the DELETE /api/labels/cleanup response
 const CleanupLabelsResponseSchema = z.object({
 	success: z.literal(true),
@@ -234,36 +228,6 @@ export async function updateLabelDescription(id: number, description: string | n
 	}
 
 	return parsed.data.label;
-}
-
-export async function deleteLabel(id: number): Promise<void> {
-	const response = await fetch(`${getApiBaseUrl()}/api/labels/${id}`, {
-		method: "DELETE",
-	});
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch (parseError: unknown) {
-		const errorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-		if (!response.ok) {
-			throw new Error(`Failed to delete label ${id}. Status: ${response.status} ${response.statusText}`);
-		}
-		throw new Error(`Unexpected response format when deleting label ${id}: ${errorMessage}`);
-	}
-
-	if (!response.ok) {
-		let errorMessage = `Failed to delete label ${id}`;
-		if (typeof data === "object" && data !== null && "message" in data && typeof data.message === "string") {
-			errorMessage = data.message;
-		}
-		throw new Error(`${errorMessage}: ${response.statusText} (Status: ${response.status})`);
-	}
-
-	const parsed = DeleteLabelResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response after deleting label. Zod errors: ${parsed.error.message}`);
-	}
 }
 
 /**


### PR DESCRIPTION
closes #971

## 目的
- MCPツールからdeleteLabelを除却する

## 変更範囲
- mcp/src/index.ts
- mcp/src/lib/apiClient.ts
- mcp/README.md
- docs/機能仕様/ラベリング機能/06_Claude連携.md

## 動作確認
- pnpm -C mcp run typecheck