### PR TITLE
MCP除却：updateLabelDescription

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -10,7 +10,6 @@
 - **`assignLabel`**: 指定された記事IDに指定されたラベル名をAPI経由で割り当てます。（引数: `articleId`, `labelName`, `description`）
 - **`getLabelById`**: 特定のラベルを取得します。（引数: `labelId`）
 - **`deleteLabel`**: ラベルを削除します。（引数: `labelId`）
-- **`updateLabelDescription`**: ラベルの説明を更新します。（引数: `labelId`, `description`）
 - **`assignLabelsToMultipleArticles`**: 複数の記事に一括でラベルを付与します。（引数: `articleIds`, `labelName`, `description`）
 
 ### ブックマーク管理ツール

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -176,45 +176,7 @@ server.tool(
 	},
 );
 
-// 6. Tool to update a label's description
-server.tool(
-	"updateLabelDescription",
-	{
-		labelId: z.number().int().positive(),
-		description: z.string().nullable(),
-	},
-	async ({ labelId, description }) => {
-		try {
-			const updatedLabel = await apiClient.updateLabelDescription(labelId, description);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Successfully updated label description: ${JSON.stringify(updatedLabel, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(
-				`Error in updateLabelDescription tool (labelId: ${labelId}, description: ${description}):`,
-				errorMessage,
-			);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Failed to update label description: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 7. Tool to assign labels to multiple articles
+// 6. Tool to assign labels to multiple articles
 server.tool(
 	"assignLabelsToMultipleArticles",
 	// Define input arguments schema using Zod
@@ -270,7 +232,7 @@ server.tool(
 	},
 );
 
-// 8. Tool to get unread bookmarks
+// 7. Tool to get unread bookmarks
 server.tool(
 	"getUnreadBookmarks",
 	{}, // No input arguments
@@ -302,7 +264,7 @@ server.tool(
 	},
 );
 
-// 9. Tool to mark bookmark as read
+// 8. Tool to mark bookmark as read
 server.tool(
 	"markBookmarkAsRead",
 	{

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -47,12 +47,6 @@ const GetLabelByIdResponseSchema = z.object({
 	label: LabelSchema,
 });
 
-// Schema for the PATCH /api/labels/:id response
-const UpdateLabelDescriptionResponseSchema = z.object({
-	success: z.literal(true),
-	label: LabelSchema,
-});
-
 // Schema for the DELETE /api/labels/:id response
 const DeleteLabelResponseSchema = z.object({
 	success: z.literal(true),
@@ -196,41 +190,6 @@ export async function getLabelById(id: number) {
 	const parsed = GetLabelByIdResponseSchema.safeParse(data);
 	if (!parsed.success) {
 		throw new Error(`Invalid API response for label ${id}: ${parsed.error.message}`);
-	}
-
-	return parsed.data.label;
-}
-
-/**
- * Updates a label's description via the API.
- * @param id - The ID of the label to update.
- * @param description - The new description (or null to remove the description).
- * @returns A promise that resolves to the updated label object.
- */
-export async function updateLabelDescription(id: number, description: string | null) {
-	const response = await fetch(`${getApiBaseUrl()}/api/labels/${id}`, {
-		method: "PATCH",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({ description }),
-	});
-
-	if (!response.ok) {
-		throw new Error(`Failed to update description for label ${id}: ${response.statusText}`);
-	}
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch (parseError: unknown) {
-		const errorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-		throw new Error(`Failed to parse response when updating label ${id} description: ${errorMessage}`);
-	}
-
-	const parsed = UpdateLabelDescriptionResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response after updating label description: ${parsed.error.message}`);
 	}
 
 	return parsed.data.label;


### PR DESCRIPTION
closes #972

## 目的
- MCPツールからupdateLabelDescriptionを除却する

## 変更範囲
- mcp/src/index.ts
- mcp/src/lib/apiClient.ts
- mcp/README.md

## 動作確認
- pnpm -C mcp run typecheck