### PR TITLE
MCP除却：markBookmarkAsRead

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -13,7 +13,6 @@
 
 ### ブックマーク管理ツール
 - **`getUnreadBookmarks`**: 未読ブックマークを取得します。（引数なし）
-- **`markBookmarkAsRead`**: 指定ブックマークを既読にします。（引数: `bookmarkId`）
 
 ## Connecting with a Client
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -230,40 +230,6 @@ server.tool(
 	},
 );
 
-// 7. Tool to mark bookmark as read
-server.tool(
-	"markBookmarkAsRead",
-	{
-		bookmarkId: z.number().int().positive(),
-	},
-	async ({ bookmarkId }) => {
-		try {
-			const result = await apiClient.markBookmarkAsRead(bookmarkId);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `ブックマークID: ${bookmarkId}を既読にマークしました。\n${JSON.stringify(result, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(`Error in markBookmarkAsRead tool (bookmarkId: ${bookmarkId}):`, errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `ブックマークの既読マークに失敗しました: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
 // --- End Tool Definition ---
 
 async function main() {

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -265,12 +265,6 @@ export async function assignLabelsToMultipleArticles(
 	};
 }
 
-// Schema for mark as read response
-const MarkAsReadResponseSchema = z.object({
-	success: z.literal(true),
-	message: z.string(),
-});
-
 /**
  * 未読のブックマークを取得します
  * @returns 未読のブックマークのリスト
@@ -307,23 +301,6 @@ export async function getUnreadBookmarks() {
  * @param bookmarkId - ブックマークID
  * @returns 処理結果
  */
-export async function markBookmarkAsRead(bookmarkId: number) {
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks/${bookmarkId}/read`, {
-		method: "PATCH",
-	});
-
-	if (!response.ok) {
-		throw new Error(`Failed to mark bookmark ${bookmarkId} as read: ${response.statusText}`);
-	}
-
-	const data = await response.json();
-	const parsed = MarkAsReadResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response after marking bookmark as read: ${parsed.error.message}`);
-	}
-	return parsed.data;
-}
-
 /**
  * 未使用ラベルをクリーンアップします
  * @returns クリーンアップの結果


### PR DESCRIPTION
closes #970\n\n## 目的\n- MCPサーバーからmarkBookmarkAsReadツールと対応するAPIクライアント処理を除却する\n\n## 変更範囲\n- mcp/src/index.ts\n- mcp/src/lib/apiClient.ts\n- mcp/README.md\n\n## 動作確認\n- pnpm -C mcp run typecheck