### PR TITLE
🚚 chore: GitHubホステッドランナーへ移行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,12 +17,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Clean pnpm setup directory
-        run: |
-          # pnpm/action-setupのデフォルトディレクトリをクリーンアップ
-          rm -rf ~/setup-pnpm || true
-          rm -rf /home/runner-user/setup-pnpm || true
-
       - uses: pnpm/action-setup@v4
         with:
           version: 9.14.4


### PR DESCRIPTION
## 目的
セルフホストランナー除却に伴い、Deploy CI を GitHub ホステッドランナーへ移行する。

## 変更点
- Deploy ワークフローの `runs-on` を `ubuntu-latest` へ更新
- セルフホスト専用だった pnpm セットアップディレクトリのクリーンアップ手順を削除

## 動作確認
- [ ] `workflow_dispatch` で Deploy ワークフローを手動実行し正しく完了することを確認
- [ ] main ブランチへの push により自動起動することを確認（必要に応じて）
