### PR TITLE
🐛 fix: assignLabelsToMultipleArticlesのラベル判定を修正

### DIFF
--- a/api/src/interfaces/repository/articleLabel.ts
+++ b/api/src/interfaces/repository/articleLabel.ts
@@ -27,9 +27,13 @@ export interface IArticleLabelRepository {
 	): Promise<ArticleLabel[]>;
 
 	/**
-	 * 指定された記事IDのリストに対してラベルが付与されているかを一括で確認します。
+	 * 指定された記事IDのリストに対して、特定のラベルが付与されているかを一括で確認します。
 	 * @param articleIds 記事IDの配列
+	 * @param labelId 判定対象のラベルID
 	 * @returns 既にラベルが付与されている記事IDのSet
 	 */
-	findExistingArticleIds(articleIds: number[]): Promise<Set<number>>;
+	findExistingArticleIds(
+		articleIds: number[],
+		labelId: number,
+	): Promise<Set<number>>;
 }

--- a/api/src/repositories/articleLabel.ts
+++ b/api/src/repositories/articleLabel.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import {
 	type ArticleLabel,
@@ -55,11 +55,19 @@ export class ArticleLabelRepository implements IArticleLabelRepository {
 		return results;
 	}
 
-	async findExistingArticleIds(articleIds: number[]): Promise<Set<number>> {
+	async findExistingArticleIds(
+		articleIds: number[],
+		labelId: number,
+	): Promise<Set<number>> {
 		const existingLabels = await this.db
 			.select({ articleId: articleLabels.articleId })
 			.from(articleLabels)
-			.where(inArray(articleLabels.articleId, articleIds))
+			.where(
+				and(
+					inArray(articleLabels.articleId, articleIds),
+					eq(articleLabels.labelId, labelId),
+				),
+			)
 			.all();
 
 		return new Set(existingLabels.map((label) => label.articleId));

--- a/api/src/services/label.ts
+++ b/api/src/services/label.ts
@@ -180,7 +180,7 @@ export class LabelService implements ILabelService {
 		// 4. バッチデータ取得
 		const [bookmarkMap, existingArticleIds] = await Promise.all([
 			this.bookmarkRepository.findByIds(articleIds),
-			this.articleLabelRepository.findExistingArticleIds(articleIds),
+			this.articleLabelRepository.findExistingArticleIds(articleIds, label.id),
 		]);
 
 		// 5. 各記事の検証と結果の作成

--- a/api/tests/unit/repositories/batch-label.test.ts
+++ b/api/tests/unit/repositories/batch-label.test.ts
@@ -83,8 +83,9 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 			repository = new ArticleLabelRepository(mockDb as any);
 		});
 
-		it("既にラベル付けされている記事IDのSetを返す", async () => {
+		it("指定したラベルが付与済みの記事IDのSetを返す", async () => {
 			const articleIds = [1, 2, 3, 4];
+			const labelId = 99;
 			const existingLabels = [{ articleId: 1 }, { articleId: 3 }];
 
 			// Mock Drizzle calls
@@ -95,9 +96,13 @@ describe("バッチラベル付け関連のリポジトリメソッド", () => {
 			mockedDb.where.mockReturnThis();
 			mockedDb.all.mockResolvedValue(existingLabels);
 
-			const result = await repository.findExistingArticleIds(articleIds);
+			const result = await repository.findExistingArticleIds(
+				articleIds,
+				labelId,
+			);
 
 			expect(result).toEqual(new Set([1, 3]));
+			expect(mockedDb.where).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
## 目的
- assignLabelsToMultipleArticlesが他のラベルが付いた記事もスキップしてしまう不具合を修正する

## 変更範囲
- findExistingArticleIdsをラベルIDでフィルタするようリポジトリとサービスを更新
- 同条件を前提としたユニットテストの更新と新規追加で挙動を担保

## 動作確認
- [x] pnpm -C api run test -- --runInBand

closes #973