### PR TITLE
🐛 fix: MCP初期化時の不要ログを削除

### DIFF
--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -1,1 +1,1 @@
-console.log("Hello via Bun!");
+import "./src/index.js";


### PR DESCRIPTION
## 目的
- MCP サーバー起動時に `Hello via Bun!` が出力され JSON パースが失敗する問題を解消する

## 変更範囲
- `mcp/index.ts` から不要な `console.log("Hello via Bun!")` を除去し、サーバー本体のみを読み込むように修正

## 動作確認
- [x] pnpm -C mcp run build

closes #987