### PR TITLE
🧹 chore: Biome推奨ルール適用とa11y修正

### DIFF
--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -140,13 +140,13 @@ if (import.meta.vitest) {
 	const { test, expect, describe, beforeEach, afterEach } = import.meta.vitest;
 
 	describe("Configuration Module", () => {
-		// @ts-ignore: process is available in test environment
+		// @ts-expect-error: process is available in test environment
 		const originalEnv =
 			typeof process !== "undefined" ? { ...process.env } : {};
 
 		beforeEach(() => {
 			// テスト環境でのみ環境変数をリセット
-			// @ts-ignore: process is available in test environment
+			// @ts-expect-error: process is available in test environment
 			if (typeof process !== "undefined") {
 				for (const key of Object.keys(process.env)) {
 					if (
@@ -164,7 +164,7 @@ if (import.meta.vitest) {
 
 		afterEach(() => {
 			// テスト環境でのみ環境変数を復元
-			// @ts-ignore: process is available in test environment
+			// @ts-expect-error: process is available in test environment
 			if (typeof process !== "undefined") {
 				process.env = { ...originalEnv };
 			}
@@ -317,7 +317,7 @@ if (import.meta.vitest) {
 
 		describe("process.env 使用時のテスト（Node.js環境のみ）", () => {
 			test("process.envが利用可能な場合の環境変数読み込み", () => {
-				// @ts-ignore: process is available in test environment
+				// @ts-expect-error: process is available in test environment
 				if (typeof process !== "undefined") {
 					process.env.DEFAULT_OFFSET = "10";
 					process.env.DEFAULT_PAGE_SIZE = "50";

--- a/api/src/services/BookshelfService.ts
+++ b/api/src/services/BookshelfService.ts
@@ -321,7 +321,7 @@ if (import.meta.vitest) {
 
 		describe("内部バリデーションメソッド", () => {
 			test("isValidTypeが正しいタイプを判定する", () => {
-				// テスト用ヘルパーメソッドを使用（@ts-ignore不要）
+				// テスト用ヘルパーメソッドを使用（型エラー抑制コメントは不要）
 				expect(service._testHelpers.isValidType("book")).toBe(true);
 				expect(service._testHelpers.isValidType("pdf")).toBe(true);
 				expect(service._testHelpers.isValidType("github")).toBe(true);

--- a/api/src/utils/validation.ts
+++ b/api/src/utils/validation.ts
@@ -8,7 +8,7 @@ import { BadRequestError } from "../exceptions";
  * 文字列からIDを検証し、数値として返す
  */
 export function validateId(value: string, fieldName = "ID"): number {
-	const id = Number.parseInt(value);
+	const id = Number.parseInt(value, 10);
 	if (Number.isNaN(id)) {
 		throw new BadRequestError(`Invalid ${fieldName}`);
 	}
@@ -58,7 +58,7 @@ export function validateIdArray(
 	}
 
 	return values.map((value, _index) => {
-		const id = Number.parseInt(String(value));
+		const id = Number.parseInt(String(value), 10);
 		if (Number.isNaN(id)) {
 			// Keep the original error message format for consistency
 			let singularName = fieldName;

--- a/api/tests/unit/routes/labels.test.ts
+++ b/api/tests/unit/routes/labels.test.ts
@@ -164,7 +164,7 @@ function createMockLabelsRouter() {
 	// ラベル取得（ID指定）
 	router.get("/:id", async (c) => {
 		try {
-			const id = Number.parseInt(c.req.param("id"));
+			const id = Number.parseInt(c.req.param("id"), 10);
 			if (Number.isNaN(id)) {
 				return c.json({ success: false, message: "Invalid label ID" }, 400);
 			}
@@ -187,7 +187,7 @@ function createMockLabelsRouter() {
 	// ラベル説明文更新
 	router.patch("/:id", async (c) => {
 		try {
-			const id = Number.parseInt(c.req.param("id"));
+			const id = Number.parseInt(c.req.param("id"), 10);
 			if (Number.isNaN(id)) {
 				return c.json({ success: false, message: "Invalid label ID" }, 400);
 			}
@@ -241,7 +241,7 @@ function createMockLabelsRouter() {
 	// ラベル削除
 	router.delete("/:id", async (c) => {
 		try {
-			const id = Number.parseInt(c.req.param("id"));
+			const id = Number.parseInt(c.req.param("id"), 10);
 			if (Number.isNaN(id)) {
 				return c.json({ success: false, message: "Invalid label ID" }, 400);
 			}

--- a/biome.json
+++ b/biome.json
@@ -30,14 +30,6 @@
 		"enabled": true,
 		"rules": {
 			"recommended": true,
-			"a11y": {
-				"noSvgWithoutTitle": "off",
-				"useSemanticElements": "off"
-			},
-			"suspicious": {
-				"noArrayIndexKey": "off",
-				"noConfusingVoidType": "off"
-			},
 			"style": {
 				"noParameterAssign": "error",
 				"useAsConstAssertion": "error",

--- a/frontend/src/app/bookshelf/[id]/page.tsx
+++ b/frontend/src/app/bookshelf/[id]/page.tsx
@@ -160,14 +160,14 @@ export default function BookshelfDetailPage() {
 		return (
 			<div className="container mx-auto px-4 py-8">
 				<div className="max-w-2xl mx-auto">
-					<div role="status" aria-live="polite">
-						<span className="sr-only">データを読み込み中です</span>
-						<div className="animate-pulse">
-							<div className="h-32 bg-gray-200 rounded mb-4" />
-							<div className="h-8 bg-gray-200 rounded mb-4" />
-							<div className="h-4 bg-gray-200 rounded w-1/2" />
-						</div>
-					</div>
+						<output role="status" aria-live="polite" className="block">
+							<span className="sr-only">データを読み込み中です</span>
+							<div className="animate-pulse">
+								<div className="h-32 bg-gray-200 rounded mb-4" />
+								<div className="h-8 bg-gray-200 rounded mb-4" />
+								<div className="h-4 bg-gray-200 rounded w-1/2" />
+							</div>
+						</output>
 				</div>
 			</div>
 		);

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -40,6 +40,8 @@ export default function ErrorPage({
 							className="h-5 w-5 text-red-400"
 							viewBox="0 0 20 20"
 							fill="currentColor"
+							aria-hidden="true"
+							focusable="false"
 						>
 							<path
 								fillRule="evenodd"

--- a/frontend/src/app/favorites/page.tsx
+++ b/frontend/src/app/favorites/page.tsx
@@ -11,6 +11,11 @@ interface FavoritesApiResponse {
 	bookmarks: BookmarkWithLabel[];
 }
 
+const FAVORITES_SKELETON_KEYS = Array.from(
+	{ length: 6 },
+	(_, index) => `favorites-skeleton-${index}`,
+);
+
 // お気に入りブックマーク一覧を取得する非同期関数
 const fetchFavoriteBookmarks = async (): Promise<FavoritesApiResponse> => {
 	const response = await fetch(`${API_BASE_URL}/api/bookmarks/favorites`);
@@ -51,9 +56,9 @@ export default function FavoritesPage() {
 			{isLoading ? (
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 					{/* スケルトンローディング表示 */}
-					{[...Array(6)].map((_, i) => (
+					{FAVORITES_SKELETON_KEYS.map((skeletonKey) => (
 						<div
-							key={i}
+							key={skeletonKey}
 							className="border rounded-lg p-4 h-[150px] bg-gray-100 animate-pulse"
 						/>
 					))}

--- a/frontend/src/app/labels/page.tsx
+++ b/frontend/src/app/labels/page.tsx
@@ -59,6 +59,8 @@ export default function LabelsPage() {
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,14 +1,16 @@
+const LOADING_SKELETON_KEYS = Array.from(
+	{ length: 6 },
+	(_, index) => `loading-placeholder-${index}`,
+);
+
 export default function Loading() {
 	return (
 		<div className="container mx-auto px-4 py-8">
 			<div className="animate-pulse">
 				<div className="h-8 bg-gray-200 rounded-sm w-1/4 mb-6" />
 				<div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-					{[...Array(6)].map((_, index) => (
-						<div
-							key={`loading-placeholder-${index}`}
-							className="h-32 bg-gray-200 rounded-sm"
-						/>
+					{LOADING_SKELETON_KEYS.map((skeletonKey) => (
+						<div key={skeletonKey} className="h-32 bg-gray-200 rounded-sm" />
 					))}
 				</div>
 			</div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -32,6 +32,11 @@ const fetchBookmarks = async (
 	return data;
 };
 
+const HOMEPAGE_SKELETON_KEYS = Array.from(
+	{ length: 6 },
+	(_, index) => `home-skeleton-${index}`,
+);
+
 export default function HomePage() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -113,9 +118,9 @@ export default function HomePage() {
 			{isLoadingBookmarks ? (
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 					{/* スケルトンローディング表示 (簡易版) */}
-					{[...Array(6)].map((_, i) => (
+					{HOMEPAGE_SKELETON_KEYS.map((skeletonKey) => (
 						<div
-							key={i}
+							key={skeletonKey}
 							className="border rounded-lg p-4 h-[150px] bg-gray-100 animate-pulse"
 						/>
 					))}

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -120,6 +120,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
 				}`}
 				title={isUrlCopied ? "URLをコピーしました！" : "URLをコピー"}
+				aria-label={isUrlCopied ? "URLをコピーしました" : "URLをコピー"}
 			>
 				{isUrlCopied ? (
 					<svg
@@ -129,6 +130,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						strokeWidth={1.5}
 						stroke="currentColor"
 						className="w-6 h-6"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"
@@ -146,6 +149,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						strokeWidth={1.5}
 						stroke="currentColor"
 						className="w-6 h-6"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"
@@ -166,6 +171,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
 				}`}
 				title={isCopied ? "コピーしました！" : `ID: ${id}をコピー`}
+				aria-label={isCopied ? "IDをコピーしました" : `ID: ${id}をコピー`}
 			>
 				{isCopied ? (
 					<svg
@@ -175,6 +181,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						strokeWidth={1.5}
 						stroke="currentColor"
 						className="w-6 h-6"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"
@@ -190,6 +198,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						strokeWidth={1.5}
 						stroke="currentColor"
 						className="w-6 h-6"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"
@@ -213,9 +223,16 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 							: "text-gray-400 hover:text-yellow-500"
 				}`}
 				title={isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
+				aria-label={isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
 			>
 				{isTogglingFavorite ? (
-					<div className="animate-spin h-6 w-6 border-2 border-current border-t-transparent rounded-full" />
+					<>
+						<div
+							className="animate-spin h-6 w-6 border-2 border-current border-t-transparent rounded-full"
+							aria-hidden="true"
+						/>
+						<span className="sr-only">処理中</span>
+					</>
 				) : (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
@@ -224,6 +241,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 						strokeWidth={1.5}
 						stroke="currentColor"
 						className="w-6 h-6"
+						aria-hidden="true"
+						focusable="false"
 					>
 						<path
 							strokeLinecap="round"
@@ -240,6 +259,7 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 				onClick={handleShare}
 				className="absolute bottom-2 right-10 p-1 rounded-full text-gray-400 hover:text-blue-500 hover:bg-blue-50"
 				title="Xでシェア"
+				aria-label="Xでシェア"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -247,6 +267,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					height="24"
 					viewBox="0 0 24 24"
 					className="w-6 h-6"
+					aria-hidden="true"
+					focusable="false"
 				>
 					<path
 						fill="currentColor"
@@ -268,29 +290,34 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 							: "text-gray-400 hover:text-green-500 hover:bg-green-50"
 					}`}
 					title="既読にする"
+					aria-label={isMarkingAsRead ? "既読に変更中" : "既読にする"}
 				>
 					{isMarkingAsRead ? (
-						<svg
-							className="animate-spin w-6 h-6"
-							xmlns="http://www.w3.org/2000/svg"
-							fill="none"
-							viewBox="0 0 24 24"
-							role="status"
-						>
-							<circle
-								className="opacity-25"
-								cx="12"
-								cy="12"
-								r="10"
-								stroke="currentColor"
-								strokeWidth="4"
-							/>
-							<path
-								className="opacity-75"
-								fill="currentColor"
-								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-							/>
-						</svg>
+						<>
+							<svg
+								className="animate-spin w-6 h-6"
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								aria-hidden="true"
+								focusable="false"
+							>
+								<circle
+									className="opacity-25"
+									cx="12"
+									cy="12"
+									r="10"
+									stroke="currentColor"
+									strokeWidth="4"
+								/>
+								<path
+									className="opacity-75"
+									fill="currentColor"
+									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+								/>
+							</svg>
+							<span className="sr-only">既読に変更中</span>
+						</>
 					) : (
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
@@ -299,6 +326,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 							strokeWidth={1.5}
 							stroke="currentColor"
 							className="w-6 h-6"
+							aria-hidden="true"
+							focusable="false"
 						>
 							<path
 								strokeLinecap="round"
@@ -320,29 +349,34 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 							: "text-green-500 hover:text-blue-500 hover:bg-blue-50"
 					}`}
 					title="未読に戻す"
+					aria-label={isMarkingAsUnread ? "未読に戻す処理中" : "未読に戻す"}
 				>
 					{isMarkingAsUnread ? (
-						<svg
-							className="animate-spin w-6 h-6"
-							xmlns="http://www.w3.org/2000/svg"
-							fill="none"
-							viewBox="0 0 24 24"
-							role="status"
-						>
-							<circle
-								className="opacity-25"
-								cx="12"
-								cy="12"
-								r="10"
-								stroke="currentColor"
-								strokeWidth="4"
-							/>
-							<path
-								className="opacity-75"
-								fill="currentColor"
-								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-							/>
-						</svg>
+						<>
+							<svg
+								className="animate-spin w-6 h-6"
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								aria-hidden="true"
+								focusable="false"
+							>
+								<circle
+									className="opacity-25"
+									cx="12"
+									cy="12"
+									r="10"
+									stroke="currentColor"
+									strokeWidth="4"
+								/>
+								<path
+									className="opacity-75"
+									fill="currentColor"
+									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+								/>
+							</svg>
+							<span className="sr-only">未読に戻す処理中</span>
+						</>
 					) : (
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
@@ -351,6 +385,8 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 							strokeWidth={1.5}
 							stroke="currentColor"
 							className="w-6 h-6"
+							aria-hidden="true"
+							focusable="false"
 						>
 							<path
 								strokeLinecap="round"

--- a/frontend/src/features/bookshelf/components/AddBookButton.tsx
+++ b/frontend/src/features/bookshelf/components/AddBookButton.tsx
@@ -23,6 +23,8 @@ export function AddBookButton() {
 					className="h-5 w-5"
 					viewBox="0 0 20 20"
 					fill="currentColor"
+					aria-hidden="true"
+					focusable="false"
 				>
 					<path
 						fillRule="evenodd"

--- a/frontend/src/features/bookshelf/components/BookCard.tsx
+++ b/frontend/src/features/bookshelf/components/BookCard.tsx
@@ -26,13 +26,25 @@ export const BookCard = ({ book, onDelete }: BookCardProps) => {
 		switch (book.type) {
 			case "book":
 				return (
-					<svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+					<svg
+						className="w-5 h-5"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+						aria-hidden="true"
+						focusable="false"
+					>
 						<path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z" />
 					</svg>
 				);
 			case "pdf":
 				return (
-					<svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+					<svg
+						className="w-5 h-5"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+						aria-hidden="true"
+						focusable="false"
+					>
 						<path
 							fillRule="evenodd"
 							d="M4 4a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-5L9 2H4z"
@@ -42,7 +54,13 @@ export const BookCard = ({ book, onDelete }: BookCardProps) => {
 				);
 			case "github":
 				return (
-					<svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+					<svg
+						className="w-5 h-5"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+						aria-hidden="true"
+						focusable="false"
+					>
 						<path
 							fillRule="evenodd"
 							d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
@@ -52,7 +70,13 @@ export const BookCard = ({ book, onDelete }: BookCardProps) => {
 				);
 			case "zenn":
 				return (
-					<svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+					<svg
+						className="w-5 h-5"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+						aria-hidden="true"
+						focusable="false"
+					>
 						<path
 							fillRule="evenodd"
 							d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z"

--- a/frontend/src/features/labels/components/LabelDeleteConfirm.test.tsx
+++ b/frontend/src/features/labels/components/LabelDeleteConfirm.test.tsx
@@ -160,14 +160,12 @@ describe("LabelDeleteConfirm", () => {
 				/>,
 			);
 
-			// オーバーレイを取得（背景の暗い部分） - DOMツリーから直接取得
-			const overlay = document.querySelector('[role="button"]');
-			expect(overlay).toBeInTheDocument();
-
-			if (overlay) {
+				// オーバーレイボタンを取得
+				const overlay = screen.getByRole("button", {
+					name: "ダイアログを閉じる",
+				});
 				await user.click(overlay);
 				expect(mockOnCancel).toHaveBeenCalled();
-			}
 		});
 	});
 
@@ -274,13 +272,11 @@ describe("LabelDeleteConfirm", () => {
 				/>,
 			);
 
-			const overlay = document.querySelector('[role="button"]');
-			expect(overlay).toBeInTheDocument();
-
-			if (overlay) {
+				const overlay = screen.getByRole("button", {
+					name: "ダイアログを閉じる",
+				});
 				fireEvent.keyDown(overlay, { key: "Enter" });
 				expect(mockOnCancel).toHaveBeenCalled();
-			}
 		});
 
 		it("オーバーレイでSpaceキーを押すとonCancelが呼ばれる", async () => {
@@ -294,13 +290,11 @@ describe("LabelDeleteConfirm", () => {
 				/>,
 			);
 
-			const overlay = document.querySelector('[role="button"]');
-			expect(overlay).toBeInTheDocument();
-
-			if (overlay) {
+				const overlay = screen.getByRole("button", {
+					name: "ダイアログを閉じる",
+				});
 				fireEvent.keyDown(overlay, { key: " " });
 				expect(mockOnCancel).toHaveBeenCalled();
-			}
 		});
 
 		it("ダイアログ内でEnterやSpaceキーを押してもイベントが伝播しない", () => {

--- a/frontend/src/features/labels/components/LabelDeleteConfirm.tsx
+++ b/frontend/src/features/labels/components/LabelDeleteConfirm.tsx
@@ -68,13 +68,15 @@ export function LabelDeleteConfirm({
 	return (
 		<div className="fixed inset-0 z-50 overflow-y-auto">
 			{/* 背景のオーバーレイ - クリックでキャンセル */}
-			<div
+			<button
+				type="button"
 				className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
 				onClick={onCancel}
 				onKeyDown={handleOverlayKeyDown}
-				role="button"
-				tabIndex={0}
-			/>
+				aria-label="ダイアログを閉じる"
+			>
+				<span className="sr-only">ダイアログを閉じます</span>
+			</button>
 
 			<div className="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
 				{/* モーダルコンテンツ */}
@@ -96,6 +98,8 @@ export function LabelDeleteConfirm({
 									fill="none"
 									viewBox="0 0 24 24"
 									stroke="currentColor"
+									aria-hidden="true"
+									focusable="false"
 								>
 									<path
 										strokeLinecap="round"

--- a/frontend/src/features/labels/components/LabelDisplay.tsx
+++ b/frontend/src/features/labels/components/LabelDisplay.tsx
@@ -55,6 +55,8 @@ export function LabelDisplay({
 							viewBox="0 0 20 20"
 							fill="currentColor"
 							className="w-3 h-3 text-blue-600"
+							aria-hidden="true"
+							focusable="false"
 						>
 							<path
 								fillRule="evenodd"


### PR DESCRIPTION
## 概要
- Biomeのrecommendedルールに沿うよう設定を整理
- a11y警告となっていたアイコンやローディング表示のアクセシビリティを改善
- parseInt周辺のlint指摘を修正

## 変更内容
- biome.jsonから不要な無効化設定を削除
- API/テストでNumber.parseIntに基数10を付与
- フロントエンドのSVGやローディング表示、モーダルオーバーレイをアクセシブルに調整
- スケルトン表示で固定キーを使用し、推奨ルールを満たすように調整

## 動作確認
- pnpm run format
- pnpm -C api run test
- pnpm -C frontend run test:run

closes #963