### PR TITLE
CI: Wrangler警告解消によるデプロイ安定化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: ./api
           packageManager: pnpm
+          command: "deploy --minify --env \"\""
 
       - name: Deploy Frontend
         run: pnpm run deploy

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
 		"dev": "NODE_ENV=development wrangler dev --port 8787 --env development",
-		"deploy": "NODE_ENV=production wrangler deploy --minify",
+		"deploy": "NODE_ENV=production wrangler deploy --minify --env \"\"",
 		"lint": "npx @biomejs/biome check",
 		"format": "npx @biomejs/biome check --write",
 		"test": "vitest run",

--- a/api/src/config/database.ts
+++ b/api/src/config/database.ts
@@ -39,8 +39,10 @@ export function getDatabaseConfig(nodeEnv?: string): DatabaseConfig {
  * 現在の環境に基づくデータベース設定を取得する
  * @returns 現在の環境のデータベース設定
  */
-export function getCurrentDatabaseConfig(): DatabaseConfig {
-	return getDatabaseConfig(process.env.NODE_ENV);
+export function getCurrentDatabaseConfig(
+	nodeEnv: string | undefined = process.env.NODE_ENV,
+): DatabaseConfig {
+	return getDatabaseConfig(nodeEnv);
 }
 
 if (import.meta.vitest) {
@@ -90,20 +92,11 @@ if (import.meta.vitest) {
 
 	describe("getCurrentDatabaseConfig", () => {
 		test("現在の環境変数に基づいて設定を返す", () => {
-			const originalEnv = process.env.NODE_ENV;
+			const productionConfig = getCurrentDatabaseConfig("production");
+			expect(productionConfig.environment).toBe("production");
 
-			// 本番環境をテスト
-			process.env.NODE_ENV = "production";
-			let config = getCurrentDatabaseConfig();
-			expect(config.environment).toBe("production");
-
-			// 開発環境をテスト
-			process.env.NODE_ENV = "development";
-			config = getCurrentDatabaseConfig();
-			expect(config.environment).toBe("development");
-
-			// 環境変数をリストア
-			process.env.NODE_ENV = originalEnv;
+			const developmentConfig = getCurrentDatabaseConfig("development");
+			expect(developmentConfig.environment).toBe("development");
 		});
 	});
 }

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -37,17 +37,19 @@
 	"triggers": {
 		"crons": ["0 0 * * *"]
 	},
-	"dev": {
-		"vars": {
-			"ENVIRONMENT": "development"
-		},
-		// 開発環境用のローカルD1データベース設定
-		"d1_databases": [
-			{
-				"binding": "DB",
-				"database_name": "yomimono-db-dev",
-				"database_id": "local-dev-db"
-			}
-		]
+	"env": {
+		"development": {
+			"vars": {
+				"ENVIRONMENT": "development"
+			},
+			// 開発環境用のローカルD1データベース設定
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "yomimono-db-dev",
+					"database_id": "local-dev-db"
+				}
+			]
+		}
 	}
 }


### PR DESCRIPTION
## 目的
- Cloudflare Wrangler deploy 時の警告を解消し、CI デプロイを安定させる

## 変更範囲
- .github/workflows/deploy.yml
- api/wrangler.jsonc
- api/package.json
- api/src/config/database.ts
- api/src/services/seed.ts

## 動作確認
- cd api && CLOUDFLARE_ACCOUNT_ID=dummy CLOUDFLARE_API_TOKEN=dummy pnpm wrangler deploy --dry-run --env  
- cd api && pnpm run lint
- cd api && pnpm run test

close #984