### PR TITLE
🧹 chore: カードのURLコピー機能を除去

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
@@ -168,51 +168,6 @@ describe("BookmarkCard", () => {
 		});
 	});
 
-	it("URLコピーボタンをクリックするとURLがクリップボードにコピーされる", async () => {
-		renderWithQueryClient(<BookmarkCard bookmark={mockBookmark} />);
-
-		const copyUrlButton = screen.getByTitle("URLをコピー");
-		fireEvent.click(copyUrlButton);
-
-		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-			"https://example.com",
-		);
-
-		// 成功Toast通知が表示されることを確認
-		await waitFor(() => {
-			expect(screen.getByText("URLをコピーしました")).toBeInTheDocument();
-		});
-	});
-
-	it("URLコピーボタンクリック時にクリップボードエラーが発生した場合、エラーToastを表示する", async () => {
-		// クリップボードAPIをエラーを返すようにモック
-		const mockWriteText = vi
-			.fn()
-			.mockRejectedValue(new Error("Clipboard error"));
-		Object.assign(navigator, {
-			clipboard: {
-				writeText: mockWriteText,
-			},
-		});
-
-		renderWithQueryClient(<BookmarkCard bookmark={mockBookmark} />);
-
-		const copyUrlButton = screen.getByTitle("URLをコピー");
-		fireEvent.click(copyUrlButton);
-
-		// エラーToast通知が表示されることを確認
-		await waitFor(() => {
-			expect(screen.getByText("URLのコピーに失敗しました")).toBeInTheDocument();
-		});
-
-		// モックをリセット
-		Object.assign(navigator, {
-			clipboard: {
-				writeText: vi.fn().mockResolvedValue(undefined),
-			},
-		});
-	});
-
 	it("ラベルがある場合、ラベルを表示する", () => {
 		const bookmarkWithLabel = {
 			...mockBookmark,

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -25,7 +25,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 	const { mutate: markAsUnreadMutate, isPending: isMarkingAsUnread } =
 		useMarkBookmarkAsUnread({ showToast });
 	const [isCopied, setIsCopied] = useState(false);
-	const [isUrlCopied, setIsUrlCopied] = useState(false);
 
 	const handleFavoriteToggle = () => {
 		toggleFavorite({ id, isCurrentlyFavorite: isFavorite });
@@ -74,26 +73,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		}
 	};
 
-	// URLコピー処理
-	const handleCopyUrl = async () => {
-		try {
-			await navigator.clipboard.writeText(url);
-			setIsUrlCopied(true);
-			setTimeout(() => setIsUrlCopied(false), 2000); // 2秒後にリセット
-			showToast({
-				type: "success",
-				message: "URLをコピーしました",
-				duration: 2000,
-			});
-		} catch {
-			showToast({
-				type: "error",
-				message: "URLのコピーに失敗しました",
-				duration: 3000,
-			});
-		}
-	};
-
 	return (
 		<article
 			className={`relative p-4 pb-16 border rounded-lg hover:shadow-md transition-shadow flex flex-col h-[200px] ${
@@ -109,52 +88,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					<LabelDisplay label={label} onClick={onLabelClick} />
 				</div>
 			)}
-
-			{/* URLコピーボタン */}
-			<button
-				type="button"
-				onClick={handleCopyUrl}
-				className={`absolute bottom-2 right-36 p-1 rounded-full transition-colors ${
-					isUrlCopied
-						? "text-green-500 hover:text-green-600"
-						: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
-				}`}
-				title={isUrlCopied ? "URLをコピーしました！" : "URLをコピー"}
-			>
-				{isUrlCopied ? (
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth={1.5}
-						stroke="currentColor"
-						className="w-6 h-6"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M9 12.75L11.25 15 15 9.75m6-1.5c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
-						/>
-					</svg>
-				) : (
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="24"
-						height="24"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth={1.5}
-						stroke="currentColor"
-						className="w-6 h-6"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
-						/>
-					</svg>
-				)}
-			</button>
 
 			{/* IDコピーボタン */}
 			<button


### PR DESCRIPTION
## 目的
- カード内のURLコピー機能を除却して要件に合わせる

## 変更範囲
- BookmarkCardからURLコピー処理とボタンを削除
- URLコピーに依存するテストケースを除去

## 動作確認
- cd frontend && pnpm run lint
- cd frontend && pnpm run test:run
- cd frontend && pnpm run build

close #992