### PR TITLE
🧹 chore: カードのIDコピー機能を除去

### DIFF
--- a/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
@@ -123,51 +123,6 @@ describe("BookmarkCard", () => {
 		);
 	});
 
-	it("IDコピーボタンをクリックするとIDがクリップボードにコピーされる", async () => {
-		renderWithQueryClient(<BookmarkCard bookmark={mockBookmark} />);
-
-		const copyIdButton = screen.getByTitle("ID: 1をコピー");
-		fireEvent.click(copyIdButton);
-
-		expect(navigator.clipboard.writeText).toHaveBeenCalledWith("1");
-
-		// 成功Toast通知が表示されることを確認
-		await waitFor(() => {
-			expect(screen.getByText("IDをコピーしました")).toBeInTheDocument();
-		});
-	});
-
-	it("IDコピーボタンクリック時にクリップボードエラーが発生した場合、エラーToastを表示する", async () => {
-		// クリップボードAPIをエラーを返すようにモック
-		const mockWriteText = vi
-			.fn()
-			.mockRejectedValue(new Error("Clipboard error"));
-		Object.assign(navigator, {
-			clipboard: {
-				writeText: mockWriteText,
-			},
-		});
-
-		renderWithQueryClient(<BookmarkCard bookmark={mockBookmark} />);
-
-		const copyIdButton = screen.getByTitle("ID: 1をコピー");
-		fireEvent.click(copyIdButton);
-
-		// エラーToast通知が表示されることを確認
-		await waitFor(() => {
-			expect(
-				screen.getByText("クリップボードへのコピーに失敗しました"),
-			).toBeInTheDocument();
-		});
-
-		// モックをリセット
-		Object.assign(navigator, {
-			clipboard: {
-				writeText: vi.fn().mockResolvedValue(undefined),
-			},
-		});
-	});
-
 	it("ラベルがある場合、ラベルを表示する", () => {
 		const bookmarkWithLabel = {
 			...mockBookmark,

--- a/frontend/src/features/bookmarks/components/BookmarkCard.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useMarkBookmarkAsRead } from "@/features/bookmarks/queries/useMarkBookmarkAsRead";
 import { useMarkBookmarkAsUnread } from "@/features/bookmarks/queries/useMarkBookmarkAsUnread";
 import { useToggleFavoriteBookmark } from "@/features/bookmarks/queries/useToggleFavoriteBookmark";
@@ -24,7 +23,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		useMarkBookmarkAsRead({ showToast });
 	const { mutate: markAsUnreadMutate, isPending: isMarkingAsUnread } =
 		useMarkBookmarkAsUnread({ showToast });
-	const [isCopied, setIsCopied] = useState(false);
 
 	const handleFavoriteToggle = () => {
 		toggleFavorite({ id, isCurrentlyFavorite: isFavorite });
@@ -53,26 +51,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 		}
 	};
 
-	// IDコピー処理
-	const handleCopyId = async () => {
-		try {
-			await navigator.clipboard.writeText(id.toString());
-			setIsCopied(true);
-			setTimeout(() => setIsCopied(false), 2000); // 2秒後にリセット
-			showToast({
-				type: "success",
-				message: "IDをコピーしました",
-				duration: 2000,
-			});
-		} catch {
-			showToast({
-				type: "error",
-				message: "クリップボードへのコピーに失敗しました",
-				duration: 3000,
-			});
-		}
-	};
-
 	return (
 		<article
 			className={`relative p-4 pb-16 border rounded-lg hover:shadow-md transition-shadow flex flex-col h-[200px] ${
@@ -88,50 +66,6 @@ export function BookmarkCard({ bookmark, onLabelClick }: Props) {
 					<LabelDisplay label={label} onClick={onLabelClick} />
 				</div>
 			)}
-
-			{/* IDコピーボタン */}
-			<button
-				type="button"
-				onClick={handleCopyId}
-				className={`absolute bottom-2 right-28 p-1 rounded-full transition-colors ${
-					isCopied
-						? "text-green-500 hover:text-green-600"
-						: "text-gray-400 hover:text-blue-500 hover:bg-blue-50"
-				}`}
-				title={isCopied ? "コピーしました！" : `ID: ${id}をコピー`}
-			>
-				{isCopied ? (
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth={1.5}
-						stroke="currentColor"
-						className="w-6 h-6"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M9 12.75L11.25 15 15 9.75m6-1.5c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
-						/>
-					</svg>
-				) : (
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth={1.5}
-						stroke="currentColor"
-						className="w-6 h-6"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
-						/>
-					</svg>
-				)}
-			</button>
 
 			{/* お気に入りボタン */}
 			<button


### PR DESCRIPTION
## 目的
- カード内のIDコピー機能を除却して要件に合わせる

## 変更範囲
- BookmarkCardからIDコピー処理とボタンを削除
- IDコピーに依存するテストケースを除去

## 動作確認
- cd frontend && pnpm run lint
- cd frontend && pnpm run test:run
- cd frontend && pnpm run build

close #993