### PR TITLE
CI: Wrangler deploy コマンドの環境指定を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: ./api
           packageManager: pnpm
-          command: "deploy --minify --env \"\""
+          command: "deploy --minify --env=\"\""
 
       - name: Deploy Frontend
         run: pnpm run deploy

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,7 @@
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
 		"dev": "NODE_ENV=development wrangler dev --port 8787 --env development",
-		"deploy": "NODE_ENV=production wrangler deploy --minify --env \"\"",
+		"deploy": "NODE_ENV=production wrangler deploy --minify --env=\"\"",
 		"lint": "npx @biomejs/biome check",
 		"format": "npx @biomejs/biome check --write",
 		"test": "vitest run",


### PR DESCRIPTION
## 目的
- cloudflare/wrangler-action 実行時に --env 引数が空文字として渡されるよう修正し、デプロイ失敗を防ぐ

## 変更範囲
- .github/workflows/deploy.yml
- api/package.json

## 動作確認
- cd api && CLOUDFLARE_ACCOUNT_ID=dummy CLOUDFLARE_API_TOKEN=dummy pnpm wrangler deploy --dry-run --env=
- cd api && pnpm run lint
- cd api && pnpm run test

close #984