### PR TITLE
🧹 chore: Biome設定を各パッケージに分割

### DIFF
--- a/api/biome.json
+++ b/api/biome.json
@@ -1,0 +1,57 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"includes": [
+			"**",
+			"!**/.wrangler",
+			"!**/coverage",
+			"!**/node_modules",
+			"!**/*.json",
+			"!**/*.mjs",
+			"!**/drizzle.config.ts",
+			"!**/drizzle/**"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"a11y": {
+				"noSvgWithoutTitle": "off",
+				"useSemanticElements": "off"
+			},
+			"suspicious": {
+				"noArrayIndexKey": "off",
+				"noConfusingVoidType": "off"
+			},
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/extension/biome.json
+++ b/extension/biome.json
@@ -1,0 +1,55 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"includes": [
+			"**",
+			"!**/dist",
+			"!**/coverage",
+			"!**/node_modules",
+			"!**/*.json",
+			"!**/*.mjs"
+		]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"a11y": {
+				"noSvgWithoutTitle": "off",
+				"useSemanticElements": "off"
+			},
+			"suspicious": {
+				"noArrayIndexKey": "off",
+				"noConfusingVoidType": "off"
+			},
+			"style": {
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -16,9 +16,7 @@
 			"!**/node_modules",
 			"!**/*.json",
 			"!**/*.mjs",
-			"!**/drizzle.config.ts",
-			"!**/drizzle/**",
-			"!frontend/src/app/globals.css"
+			"!src/app/globals.css"
 		]
 	},
 	"formatter": {

--- a/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
+++ b/frontend/src/features/bookmarks/components/BookmarkCard.test.tsx
@@ -2,7 +2,7 @@
  * BookmarkCardコンポーネントのテスト
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ToastProvider } from "@/providers/ToastProvider";
 import type { BookmarkWithLabel } from "../types";


### PR DESCRIPTION
## 概要
- プロジェクトルートのBiome設定を削除し、各パッケージごとの設定に分割
- API/フロント/拡張でのBiomes実行対象を適切に絞り込み
- Lintエラー解消のためBookmarkCardテストの未使用インポートを整理

## 動作確認
- cd api && pnpm run lint
- cd frontend && pnpm run lint
- cd extension && pnpm run lint
- cd frontend && pnpm run test:run

close #1004