### PR TITLE
🧾 chore: mcpのBiome設定を見直して対象範囲を統一

### DIFF
--- a/mcp/biome.json
+++ b/mcp/biome.json
@@ -15,16 +15,7 @@
 		"lineWidth": 120
 	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"suspicious": {
-				"noArrayIndexKey": "error",
-				"noConfusingVoidType": "error"
-			}
-		}
-	},
+	"linter": { "enabled": true, "rules": { "recommended": true } },
 	"javascript": {
 		"formatter": {
 			"quoteStyle": "double"


### PR DESCRIPTION
## 目的
- mcp 配下のファイルも Biome で検査できるようにする

## 変更範囲
- mcp/biome.json

## 動作確認
- cd mcp && pnpm run lint
- cd mcp && pnpm run format

## スクリーンショット
- 対象外

close #963