### PR TITLE
🧹 chore: 拡張機能のBiome推奨設定のみを適用

### DIFF
--- a/extension/biome.json
+++ b/extension/biome.json
@@ -24,27 +24,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
-			"a11y": {
-				"noSvgWithoutTitle": "off",
-				"useSemanticElements": "off"
-			},
-			"suspicious": {
-				"noArrayIndexKey": "off",
-				"noConfusingVoidType": "off"
-			},
-			"style": {
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error"
-			}
+			"recommended": true
 		}
 	},
 	"javascript": {


### PR DESCRIPTION
## 目的\n- 拡張機能のBiome設定を推奨ルールのみで統一するため\n\n## 変更内容\n- biome.json の拡張ルール無効化設定を削除し recommended のみ適用\n\n## 動作確認\n- pnpm run lint\n- pnpm run build\n- pnpm run typecheck\n\nclose #1008