### PR TITLE
🛠️ chore: MCP設計見直しとテスト整備

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -45,3 +45,7 @@ jobs:
       - name: Run type check
         working-directory: ./mcp
         run: pnpm run typecheck
+
+      - name: Run tests
+        working-directory: ./mcp
+        run: pnpm run test

--- a/docs/設計/mcp-サーバー設計.md
+++ b/docs/設計/mcp-サーバー設計.md
@@ -1,0 +1,45 @@
+# MCPサーバー設計
+
+## 目的
+MCPサーバー (`mcp` パッケージ) は、Effective Yomimono のラベリング業務を支援するクライアント（Claude Desktop など）から API への操作を仲介する。ここでは現行アーキテクチャの把握と、Vitest を利用したテスト戦略、および改善候補を整理する。
+
+## システム構成概要
+- **通信レイヤー**: `src/index.ts` で `@modelcontextprotocol/sdk` の `McpServer` を生成し、`StdioServerTransport` に接続してリクエストループを保持する。
+- **ツール定義層**: `src/tools.ts` で6つのツール (`getUnlabeledArticles`, `getLabels`, `assignLabel`, `getLabelById`, `assignLabelsToMultipleArticles`, `getUnreadBookmarks`) を登録し、それぞれが API クライアント経由で外部 API を呼び出す。
+- **APIクライアント層**: `src/lib/apiClient.ts` が HTTP リクエストを担い、`fetch` と `zod` 検証でレスポンスを整形する。エンドポイントは `/api/bookmarks/*` および `/api/labels/*`。
+- **設定**: 環境変数 `API_BASE_URL` を必須とし、`tsconfig.json` で ESNext 向けのビルドと `build/` への出力を指定。`vitest.config.ts` は Node 環境・`src/**/*.ts` のカバレッジ収集を設定。
+
+## データフロー
+1. クライアントが MCP ツールを呼び出す。
+2. ツールハンドラが `apiClient` の該当メソッドを実行。
+3. `apiClient` は `API_BASE_URL` を組み立てて `fetch` し、`zod` でレスポンスを検証。
+4. 成功時はライトウェイトな DTO を返却し、MCP プロトコルのレスポンスとして文字列化される。失敗時は例外を握りつぶさず `console.error` とエラーメッセージを返す。
+
+## テスト方針 (Vitest)
+### 単体テスト対象
+- `apiClient` 各関数: `fetch` をモックし、成功レスポンス・バリデーション失敗・HTTP エラーの分岐を検証する。
+- ツール登録 (`server.tool`): `apiClient` をスパイし、入力検証やエラー伝搬を確認する軽量テストを想定。
+
+### 実装ガイドライン
+- `vitest` を `devDependencies` に追加し、`"test": "vitest run"` スクリプトを `package.json` に定義する。（済）
+- テストファイル配置は `src/lib/apiClient.test.ts` や `src/tools.test.ts` など `src` 直下に配置し、`vitest.config.ts` の `include` パターンに合致させる。
+- `fetch` モックには `vi.stubGlobal("fetch", ...)` を利用し、テスト毎にリセットする。`beforeEach` / `afterEach` で状態をクリアし、副作用を回避。
+- レスポンス検証では `safeParse` の `error.message` をアサートすることで実装依存を避ける。
+
+### カバレッジおよび品質確認
+- 追加するテストで `apiClient.ts` の主要分岐を網羅し、将来的にはツール層も含めた 80% 以上のライン・ブランチカバレッジを目標とする。
+- CI 運用を想定し `pnpm run test -- --run` を基本コマンドとする。カバレッジレポートは `coverage/` に出力されるため `.gitignore` 済みであることを再確認する。
+
+## アーキテクチャ改善候補
+1. **API クライアントの抽象化拡張**  
+   - `requestJson` / `requestVoid` ヘルパーを導入し、HTTP エラー整形と Zod 検証を共通化済み。今後はタイムアウト制御やリトライ、構造化ログの注入などを拡張ポイントとして検討する。
+2. **環境変数バリデーション**  
+   - `dotenv` 初期化直後に `API_BASE_URL` の存在チェックを実行し、サーバー起動前に失敗させることで運用時の事故を防ぐ。
+3. **テレメトリの整備**  
+   - バッチ付与 (`assignLabelsToMultipleArticles`) では処理件数やスキップ件数をログに残しているが、構造化ログや計測に発展させる余地がある。
+4. **ツール応答形式の標準化**  
+   - 現在はテキスト JSON 文字列を返している。将来的には `type: "json"` レスポンスや独自フォーマットを検討し、クライアントでのパース負荷を軽減する。
+
+## 今後のタスク
+- 追加済みのサンプルテストを拡張し、ツール層のエッジケースやリトライ対象例外をカバーする。
+- 改善項目（リトライ・構造化ログ等）の試行結果を ADR もしくは設計書に追記し、合意形成を進める。

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,7 +7,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.6",
 		"@types/node": "^24.9.0",
-		"dotenv": "^17.2.3"
+		"dotenv": "^17.2.3",
+		"vitest": "^2.1.3"
 	},
 	"peerDependencies": {
 		"typescript": "^5.8.3"
@@ -17,7 +18,8 @@
 		"build": "tsc",
 		"lint": "biome check .",
 		"format": "biome check --write .",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.20.1",

--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@24.9.0)
 
 packages:
 
@@ -86,12 +89,295 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@modelcontextprotocol/sdk@1.20.1':
     resolution: {integrity: sha512-j/P+yuxXfgxb+mW7OEoRCM3G47zCTDqUPivJo/VzpjbG8I9csTXtOprCf5FfOfHK4whOJny0aHuBEON+kS7CCA==}
     engines: {node: '>=18'}
 
+  '@rollup/rollup-android-arm-eabi@4.52.5':
+    resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.5':
+    resolution: {integrity: sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.5':
+    resolution: {integrity: sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.5':
+    resolution: {integrity: sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.5':
+    resolution: {integrity: sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.5':
+    resolution: {integrity: sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
+    resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
+    resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.5':
+    resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.5':
+    resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.5':
+    resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
+    resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
+    resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.5':
+    resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.5':
+    resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.5':
+    resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.5':
+    resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.5':
+    resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.5':
+    resolution: {integrity: sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.5':
+    resolution: {integrity: sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.5':
+    resolution: {integrity: sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.5':
+    resolution: {integrity: sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@24.9.0':
     resolution: {integrity: sha512-MKNwXh3seSK8WurXF7erHPJ2AONmMwkI7zAMrXZDPIru8jRqkk6rGDBVbw4mLwfqA+ZZliiDPg05JQ3uW66tKQ==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -99,6 +385,10 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -108,6 +398,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -115,6 +409,14 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
@@ -149,6 +451,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -176,12 +482,23 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -194,6 +511,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -222,6 +543,11 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -274,6 +600,12 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -296,6 +628,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -327,9 +664,23 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -350,6 +701,11 @@ packages:
   raw-body@3.0.1:
     resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
     engines: {node: '>= 0.10'}
+
+  rollup@4.52.5:
+    resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -396,6 +752,16 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -403,6 +769,27 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -431,9 +818,75 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -496,6 +949,77 @@ snapshots:
   '@biomejs/cli-win32-x64@2.2.6':
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@modelcontextprotocol/sdk@1.20.1':
     dependencies:
       ajv: 6.12.6
@@ -513,9 +1037,117 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rollup/rollup-android-arm-eabi@4.52.5':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.5':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.5':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.5':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.5':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.5':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.5':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
   '@types/node@24.9.0':
     dependencies:
       undici-types: 7.16.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.9.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.9.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   accepts@2.0.0:
     dependencies:
@@ -528,6 +1160,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  assertion-error@2.0.1: {}
 
   body-parser@2.2.0:
     dependencies:
@@ -545,6 +1179,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -554,6 +1190,16 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.1: {}
 
   content-disposition@1.0.0:
     dependencies:
@@ -580,6 +1226,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   depd@2.0.0: {}
 
   dotenv@17.2.3: {}
@@ -598,11 +1246,43 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -611,6 +1291,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expect-type@1.2.2: {}
 
   express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
@@ -667,6 +1349,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   get-intrinsic@1.3.0:
@@ -721,6 +1406,12 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -734,6 +1425,8 @@ snapshots:
       mime-db: 1.54.0
 
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
 
@@ -755,7 +1448,19 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
   pkce-challenge@5.0.0: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   proxy-addr@2.0.7:
     dependencies:
@@ -776,6 +1481,34 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       unpipe: 1.0.0
+
+  rollup@4.52.5:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.5
+      '@rollup/rollup-android-arm64': 4.52.5
+      '@rollup/rollup-darwin-arm64': 4.52.5
+      '@rollup/rollup-darwin-x64': 4.52.5
+      '@rollup/rollup-freebsd-arm64': 4.52.5
+      '@rollup/rollup-freebsd-x64': 4.52.5
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.5
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.5
+      '@rollup/rollup-linux-arm64-gnu': 4.52.5
+      '@rollup/rollup-linux-arm64-musl': 4.52.5
+      '@rollup/rollup-linux-loong64-gnu': 4.52.5
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.5
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.5
+      '@rollup/rollup-linux-riscv64-musl': 4.52.5
+      '@rollup/rollup-linux-s390x-gnu': 4.52.5
+      '@rollup/rollup-linux-x64-gnu': 4.52.5
+      '@rollup/rollup-linux-x64-musl': 4.52.5
+      '@rollup/rollup-openharmony-arm64': 4.52.5
+      '@rollup/rollup-win32-arm64-msvc': 4.52.5
+      '@rollup/rollup-win32-ia32-msvc': 4.52.5
+      '@rollup/rollup-win32-x64-gnu': 4.52.5
+      '@rollup/rollup-win32-x64-msvc': 4.52.5
+      fsevents: 2.3.3
 
   router@2.2.0:
     dependencies:
@@ -852,9 +1585,27 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   toidentifier@1.0.1: {}
 
@@ -876,9 +1627,76 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@24.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@24.9.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.5
+    optionalDependencies:
+      '@types/node': 24.9.0
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@24.9.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.9.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.9.0)
+      vite-node: 2.1.9(@types/node@24.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.9.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,249 +1,34 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as dotenv from "dotenv";
-import { z } from "zod";
-import * as apiClient from "./lib/apiClient.js";
+import { registerTools } from "./tools.js";
 
-// Configure dotenv to load environment variables quietly (no stdout noise)
+// dotenvを使って環境変数を読み込む（quiet指定で標準出力を汚さない）
 dotenv.config({ quiet: true });
 
-// Create an MCP server instance
-const server = new McpServer({
-	name: "EffectiveYomimonoLabeler", // Descriptive name for the server
-	version: "0.7.0", // Updated version after removing rating functionality
+// MCPサーバーインスタンスを生成
+export const server = new McpServer({
+	name: "EffectiveYomimonoLabeler", // サーバー識別用の名前
+	version: "0.7.0", // レーティング機能削除後のバージョン
 });
 
-// --- Tool Definitions ---
-
-// 1. Tool to get unlabeled articles
-server.tool(
-	"getUnlabeledArticles",
-	{}, // No input arguments
-	async () => {
-		try {
-			const articles = await apiClient.getUnlabeledArticles();
-			// Return the list of articles directly. Client needs to handle the structure.
-			// We'll stringify it here for simple text output, but a structured format might be better.
-			return {
-				content: [{ type: "text", text: JSON.stringify(articles, null, 2) }],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error("Error in getUnlabeledArticles tool:", errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Error fetching unlabeled articles: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 2. Tool to get existing labels
-server.tool(
-	"getLabels",
-	{}, // No input arguments
-	async () => {
-		try {
-			const labels = await apiClient.getLabels();
-			// Return the list of labels directly.
-			return {
-				content: [{ type: "text", text: JSON.stringify(labels, null, 2) }],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error("Error in getLabels tool:", errorMessage);
-			return {
-				content: [{ type: "text", text: `Error fetching labels: ${errorMessage}` }],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 3. Tool to assign a label to an article
-server.tool(
-	"assignLabel",
-	// Define input arguments schema using Zod
-	{
-		articleId: z.number().int().positive(),
-		labelName: z.string().min(1),
-		description: z.string().optional().nullable(),
-	},
-	async ({ articleId, labelName, description }) => {
-		// Destructure arguments
-		try {
-			await apiClient.assignLabelToArticle(articleId, labelName, description ?? undefined);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Successfully assigned label "${labelName}" to article ID ${articleId}.`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(
-				`Error in assignLabel tool (articleId: ${articleId}, labelName: ${labelName}, description: ${description}):`,
-				errorMessage,
-			);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Failed to assign label: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 4. Tool to get a label by ID
-server.tool(
-	"getLabelById",
-	{
-		labelId: z.number().int().positive(),
-	},
-	async ({ labelId }) => {
-		try {
-			const label = await apiClient.getLabelById(labelId);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Label details: ${JSON.stringify(label, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(`Error in getLabelById tool (labelId: ${labelId}):`, errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Failed to get label: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 5. Tool to assign labels to multiple articles
-server.tool(
-	"assignLabelsToMultipleArticles",
-	// Define input arguments schema using Zod
-	{
-		articleIds: z.array(z.number().int().positive()),
-		labelName: z.string().min(1),
-		description: z.string().optional().nullable(),
-	},
-	async ({ articleIds, labelName, description }) => {
-		// Destructure arguments
-		try {
-			// 入力値の検証
-			if (!articleIds || !Array.isArray(articleIds) || articleIds.length === 0) {
-				throw new Error("articleIds must be a non-empty array");
-			}
-			if (!labelName || typeof labelName !== "string") {
-				throw new Error("labelName must be a non-empty string");
-			}
-
-			console.error("Calling assignLabelsToMultipleArticles with:", {
-				articleIds,
-				labelName,
-				description,
-			});
-
-			const result = await apiClient.assignLabelsToMultipleArticles(articleIds, labelName, description ?? undefined);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Successfully batch assigned label "${labelName}" to articles. Result: ${JSON.stringify(result, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error(
-				`Error in assignLabelsToMultipleArticles tool (articleIds: ${JSON.stringify(articleIds)}, labelName: ${labelName}, description: ${description}):`,
-				errorMessage,
-			);
-			console.error("Full error details:", error);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `Failed to batch assign labels: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// 6. Tool to get unread bookmarks
-server.tool(
-	"getUnreadBookmarks",
-	{}, // No input arguments
-	async () => {
-		try {
-			const bookmarks = await apiClient.getUnreadBookmarks();
-			return {
-				content: [
-					{
-						type: "text",
-						text: `未読のブックマークリスト:\n${JSON.stringify(bookmarks, null, 2)}`,
-					},
-				],
-				isError: false,
-			};
-		} catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			console.error("Error in getUnreadBookmarks tool:", errorMessage);
-			return {
-				content: [
-					{
-						type: "text",
-						text: `未読ブックマークの取得に失敗しました: ${errorMessage}`,
-					},
-				],
-				isError: true,
-			};
-		}
-	},
-);
-
-// --- End Tool Definition ---
+// ツールをまとめて登録
+registerTools(server);
 
 async function main() {
-	// Use Stdio transport for initial development
+	// 初期開発ではStdioトランスポートを利用
 	const transport = new StdioServerTransport();
 
 	try {
-		// Connect the server to the transport
+		// サーバーをトランスポートに接続
 		await server.connect(transport);
 	} catch (error) {
-		// Keep console.error for actual errors (goes to stderr)
+		// 実際のエラーは標準エラー出力に流す
 		console.error("Failed to connect MCP server:", error);
-		process.exit(1); // Exit if connection fails
+		process.exit(1); // 接続に失敗した場合は終了
 	}
 }
 
-main();
+if (!process.env.VITEST) {
+	void main();
+}

--- a/mcp/src/lib/apiClient.test.ts
+++ b/mcp/src/lib/apiClient.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { assignLabelToArticle, getUnlabeledArticles } from "./apiClient.js";
+
+const API_BASE_URL = "https://api.example.test";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+describe("apiClient", () => {
+	let fetchMock: FetchMock;
+
+	beforeEach(() => {
+		process.env.API_BASE_URL = API_BASE_URL;
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		fetchMock.mockReset();
+		vi.unstubAllGlobals();
+	});
+
+	afterAll(() => {
+		delete process.env.API_BASE_URL;
+	});
+
+	it("getUnlabeledArticles: APIレスポンスを正しく整形する", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			json: async () => ({
+				success: true,
+				bookmarks: [
+					{
+						id: 1,
+						title: "記事1",
+						url: "https://example.com/1",
+						isRead: false,
+						createdAt: "2024-01-01T00:00:00.000Z",
+						updatedAt: "2024-01-02T00:00:00.000Z",
+					},
+				],
+			}),
+		});
+
+		const result = await getUnlabeledArticles();
+
+		expect(fetchMock).toHaveBeenCalledWith(`${API_BASE_URL}/api/bookmarks/unlabeled`, undefined);
+		expect(result).toEqual([
+			{
+				id: 1,
+				title: "記事1",
+				url: "https://example.com/1",
+				isRead: false,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+				label: null,
+				isFavorite: false,
+			},
+		]);
+	});
+
+	it("getUnlabeledArticles: レスポンスがスキーマに適合しない場合は例外を投げる", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			json: async () => ({
+				success: true,
+				articles: [], // 想定外のキー
+			}),
+		});
+
+		await expect(getUnlabeledArticles()).rejects.toThrowError(/Failed to fetch unlabeled articles/);
+	});
+
+	it("assignLabelToArticle: エラーレスポンスのメッセージを伝播する", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			statusText: "Bad Request",
+			json: async () => ({
+				message: "label already exists",
+			}),
+		});
+
+		await expect(assignLabelToArticle(42, "既存ラベル")).rejects.toThrowError(
+			'Failed to assign label "既存ラベル" to article 42: label already exists',
+		);
+	});
+});

--- a/mcp/src/lib/apiClient.ts
+++ b/mcp/src/lib/apiClient.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// Define schemas for API responses (adjust based on actual API implementation)
 const ArticleSchema = z.object({
 	id: z.number(),
 	title: z.string(),
@@ -21,9 +20,22 @@ const ArticleSchema = z.object({
 	updatedAt: z.string().or(z.instanceof(Date)),
 });
 
-// Export type for use in other modules
 export type BookmarkWithLabel = z.infer<typeof ArticleSchema>;
-// Correct schema to match API response { success: boolean, bookmarks: [...] }
+
+const UnlabeledArticlesResponseSchema = z.object({
+	success: z.literal(true),
+	bookmarks: z.array(
+		z.object({
+			id: z.number(),
+			title: z.string(),
+			url: z.string(),
+			isRead: z.boolean(),
+			createdAt: z.string().or(z.instanceof(Date)),
+			updatedAt: z.string().or(z.instanceof(Date)),
+		}),
+	),
+});
+
 const ArticlesResponseSchema = z.object({
 	success: z.literal(true),
 	bookmarks: z.array(ArticleSchema), // Key is 'bookmarks', not 'articles'
@@ -60,6 +72,19 @@ const CleanupLabelsResponseSchema = z.object({
 	),
 });
 
+const BatchResultSchema = z.object({
+	success: z.literal(true),
+	successful: z.number(),
+	skipped: z.number(),
+	errors: z.array(
+		z.object({
+			articleId: z.number(),
+			error: z.string(),
+		}),
+	),
+	label: LabelSchema,
+});
+
 // Get API base URL from environment variable
 function getApiBaseUrl(): string {
 	const API_BASE_URL = process.env.API_BASE_URL;
@@ -69,147 +94,130 @@ function getApiBaseUrl(): string {
 	return API_BASE_URL;
 }
 
-/**
- * Fetches unlabeled articles from the API.
- * @returns A promise that resolves to an array of unlabeled articles.
- */
-export async function getUnlabeledArticles() {
-	// Corrected path: /api/bookmarks/unlabeled
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks/unlabeled`);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch unlabeled articles: ${response.statusText}`);
-	}
-	const data = await response.json();
-
-	// /api/bookmarks/unlabeledは基本的なBookmarkオブジェクトを返すため、
-	// labelプロパティを持たない。labelをnullとして追加する。
-	const UnlabeledArticlesResponseSchema = z.object({
-		success: z.literal(true),
-		bookmarks: z.array(
-			z.object({
-				id: z.number(),
-				title: z.string(),
-				url: z.string(),
-				isRead: z.boolean(),
-				createdAt: z.string().or(z.instanceof(Date)),
-				updatedAt: z.string().or(z.instanceof(Date)),
-			}),
-		),
-	});
-
-	const parsed = UnlabeledArticlesResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		// Provide more context in the error message
-		throw new Error(
-			`Invalid API response for unlabeled articles. Expected { success: true, bookmarks: [...] }, received: ${JSON.stringify(data)}. Zod errors: ${parsed.error.message}`,
-		);
-	}
-	// Extract data from 'bookmarks' key and add label: null for compatibility
-	return parsed.data.bookmarks.map((bookmark) => ({
-		...bookmark,
-		label: null,
-		isFavorite: false, // デフォルト値を設定
-	}));
+function buildUrl(path: string): string {
+	return `${getApiBaseUrl()}${path}`;
 }
 
-/**
- * Fetches existing labels from the API.
- * @returns A promise that resolves to an array of existing labels.
- */
-export async function getLabels() {
-	const response = await fetch(`${getApiBaseUrl()}/api/labels`);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch labels: ${response.statusText}`);
-	}
-	const data: unknown = await response.json(); // Explicitly type as unknown
-	const parsed = LabelsResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		// Use parsed.error for detailed Zod errors
-		throw new Error(`Invalid API response for labels: ${parsed.error.message}`);
-	}
-	// Access success property safely through parsed data
-	if (!parsed.data.success) {
-		throw new Error(`API indicated failure when fetching labels: ${JSON.stringify(parsed.data)}`);
-	}
-	return parsed.data.labels;
-}
-
-/**
- * Assigns a label to a specific article via the API.
- * @param articleId - The ID of the article to label.
- * @param labelName - The name of the label to assign.
- * @param description - Optional description for the label if it's created.
- * @returns A promise that resolves when the label is successfully assigned.
- */
-export async function assignLabelToArticle(articleId: number, labelName: string, description?: string) {
-	// Corrected path: /api/bookmarks/:id/label
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks/${articleId}/label`, {
-		method: "PUT",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			labelName,
-			description,
-		}),
-	});
-
-	if (!response.ok) {
-		let errorMessage = response.statusText;
-		try {
-			const data: unknown = await response.json();
-			if (
-				typeof data === "object" &&
-				data !== null &&
-				"message" in data &&
-				typeof (data as { message: unknown }).message === "string"
-			) {
-				errorMessage = (data as { message: string }).message;
-			}
-		} catch (parseError: unknown) {
-			const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
-			errorMessage = `${errorMessage} (failed to parse error body: ${parseMessage})`;
+function extractErrorMessage(data: unknown): string | undefined {
+	if (typeof data === "object" && data !== null) {
+		if ("message" in data && typeof (data as { message: unknown }).message === "string") {
+			return (data as { message: string }).message;
 		}
-		throw new Error(`Failed to assign label "${labelName}" to article ${articleId}: ${errorMessage}`);
+		if ("error" in data && typeof (data as { error: unknown }).error === "string") {
+			return (data as { error: string }).error;
+		}
 	}
-	// Assuming the API returns no content or confirmation on success
-	// Check for specific success status codes if applicable (e.g., 200 OK, 204 No Content)
+	if (typeof data === "string" && data.trim().length > 0) {
+		return data;
+	}
+	return undefined;
+}
+async function requestJson<T>(
+	path: string,
+	init: RequestInit | undefined,
+	schema: z.ZodType<T>,
+	errorMessage: string,
+): Promise<T> {
+	const response = await fetch(buildUrl(path), init);
+	let data: unknown;
+	let parseError: unknown;
+
+	if (response.status !== 204) {
+		try {
+			data = await response.json();
+		} catch (error: unknown) {
+			parseError = error;
+		}
+	}
+
+	if (!response.ok) {
+		if (parseError) {
+			const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
+			throw new Error(`${errorMessage}: ${response.statusText} (failed to parse error body: ${parseMessage})`);
+		}
+		const detailedMessage = extractErrorMessage(data) ?? `${response.status} ${response.statusText}`;
+		throw new Error(`${errorMessage}: ${detailedMessage}`);
+	}
+
+	if (parseError) {
+		const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
+		throw new Error(`${errorMessage}: Failed to parse response JSON: ${parseMessage}`);
+	}
+
+	const parsed = schema.safeParse(data);
+	if (!parsed.success) {
+		throw new Error(`${errorMessage}: ${parsed.error.message}`);
+	}
+	return parsed.data;
 }
 
-/**
- * Fetches a specific label by ID from the API.
- * @param id - The ID of the label to fetch.
- * @returns A promise that resolves to the label object.
- */
-export async function getLabelById(id: number) {
-	const response = await fetch(`${getApiBaseUrl()}/api/labels/${id}`);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch label with ID ${id}: ${response.statusText}`);
+async function requestVoid(path: string, init: RequestInit | undefined, errorMessage: string): Promise<void> {
+	const response = await fetch(buildUrl(path), init);
+	if (response.ok) {
+		return;
 	}
 
 	let data: unknown;
 	try {
-		data = await response.json();
-	} catch (parseError: unknown) {
-		const errorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-		throw new Error(`Failed to parse response when fetching label ${id}: ${errorMessage}`);
+		if (response.status !== 204) {
+			data = await response.json();
+		}
+	} catch (error: unknown) {
+		const parseMessage = error instanceof Error ? error.message : String(error);
+		throw new Error(`${errorMessage}: ${response.statusText} (failed to parse error body: ${parseMessage})`);
 	}
 
-	const parsed = GetLabelByIdResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response for label ${id}: ${parsed.error.message}`);
-	}
-
-	return parsed.data.label;
+	const detailedMessage = extractErrorMessage(data) ?? `${response.status} ${response.statusText}`;
+	throw new Error(`${errorMessage}: ${detailedMessage}`);
 }
 
-/**
- * 複数の記事に一括でラベルを付与します。
- * @param articleIds - ラベルを付与する記事IDの配列
- * @param labelName - 付与するラベル名
- * @param description - ラベルの説明（オプション）
- * @returns 処理結果（成功数、スキップ数、エラー情報、ラベル）
- */
+export async function getUnlabeledArticles() {
+	const data = await requestJson(
+		"/api/bookmarks/unlabeled",
+		undefined,
+		UnlabeledArticlesResponseSchema,
+		"Failed to fetch unlabeled articles",
+	);
+
+	return data.bookmarks.map((bookmark) => ({
+		...bookmark,
+		label: null,
+		isFavorite: false,
+	}));
+}
+
+export async function getLabels() {
+	const data = await requestJson("/api/labels", undefined, LabelsResponseSchema, "Failed to fetch labels");
+	return data.labels;
+}
+
+export async function assignLabelToArticle(articleId: number, labelName: string, description?: string) {
+	await requestVoid(
+		`/api/bookmarks/${articleId}/label`,
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				labelName,
+				description,
+			}),
+		},
+		`Failed to assign label "${labelName}" to article ${articleId}`,
+	);
+}
+
+export async function getLabelById(id: number) {
+	const data = await requestJson(
+		`/api/labels/${id}`,
+		undefined,
+		GetLabelByIdResponseSchema,
+		`Failed to fetch label with ID ${id}`,
+	);
+	return data.label;
+}
+
 export async function assignLabelsToMultipleArticles(
 	articleIds: number[],
 	labelName: string,
@@ -220,84 +228,42 @@ export async function assignLabelsToMultipleArticles(
 	errors: Array<{ articleId: number; error: string }>;
 	label: z.infer<typeof LabelSchema>;
 }> {
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks/batch-label`, {
-		method: "PUT",
-		headers: {
-			"Content-Type": "application/json",
+	const data = await requestJson(
+		"/api/bookmarks/batch-label",
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				articleIds,
+				labelName,
+				description,
+			}),
 		},
-		body: JSON.stringify({
-			articleIds: articleIds,
-			labelName: labelName,
-			description: description,
-		}),
-	});
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch (parseError: unknown) {
-		const errorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-		throw new Error(`Failed to parse response for batch label assignment: ${errorMessage}`);
-	}
+		BatchResultSchema,
+		`Failed to batch assign label "${labelName}"`,
+	);
 
 	// デバッグ用：レスポンスをstderrに出力
 	console.error("Batch label assignment response:", JSON.stringify(data, null, 2));
 
-	if (!response.ok) {
-		let errorMessage = `Failed to batch assign label "${labelName}"`;
-		if (typeof data === "object" && data !== null && "message" in data && typeof data.message === "string") {
-			errorMessage = data.message;
-		}
-		throw new Error(`${errorMessage}: ${response.statusText}`);
-	}
-
-	// バッチ結果のスキーマを定義
-	const BatchResultSchema = z.object({
-		success: z.literal(true),
-		successful: z.number(),
-		skipped: z.number(),
-		errors: z.array(
-			z.object({
-				articleId: z.number(),
-				error: z.string(),
-			}),
-		),
-		label: LabelSchema,
-	});
-
-	const parsed = BatchResultSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response for batch label assignment: ${parsed.error.message}`);
-	}
-
-	// successプロパティを除いた結果を返す
 	return {
-		successful: parsed.data.successful,
-		skipped: parsed.data.skipped,
-		errors: parsed.data.errors,
-		label: parsed.data.label,
+		successful: data.successful,
+		skipped: data.skipped,
+		errors: data.errors,
+		label: data.label,
 	};
 }
 
-/**
- * 未読のブックマークを取得します
- * @returns 未読のブックマークのリスト
- */
 export async function getUnreadBookmarks() {
-	// Default behavior of /api/bookmarks is to return unread bookmarks
-	const response = await fetch(`${getApiBaseUrl()}/api/bookmarks`);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch unread bookmarks: ${response.statusText}`);
-	}
-
-	const data = await response.json();
-	// /api/bookmarksはArticleSchemaの形式で返すため、ArticlesResponseSchemaを使用
-	const parsed = ArticlesResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response for unread bookmarks: ${parsed.error.message}`);
-	}
-	// ArticleSchemaの形式をBookmarkWithReadStatusSchemaの形式に変換
-	const bookmarksWithReadStatus = parsed.data.bookmarks.map((bookmark) => ({
+	const data = await requestJson(
+		"/api/bookmarks",
+		undefined,
+		ArticlesResponseSchema,
+		"Failed to fetch unread bookmarks",
+	);
+	return data.bookmarks.map((bookmark) => ({
 		id: bookmark.id,
 		url: bookmark.url,
 		title: bookmark.title,
@@ -308,53 +274,25 @@ export async function getUnreadBookmarks() {
 		readAt: null,
 		updatedAt: typeof bookmark.updatedAt === "string" ? bookmark.updatedAt : bookmark.updatedAt.toISOString(),
 	}));
-	return bookmarksWithReadStatus;
 }
-/**
- * ブックマークを既読にマークします
- * @param bookmarkId - ブックマークID
- * @returns 処理結果
- */
-/**
- * 未使用ラベルをクリーンアップします
- * @returns クリーンアップの結果
- */
+
 export async function cleanupUnusedLabels(): Promise<{
 	deletedCount: number;
 	deletedLabels: Array<{ id: number; name: string }>;
 	message: string;
 }> {
-	const response = await fetch(`${getApiBaseUrl()}/api/labels/cleanup`, {
-		method: "DELETE",
-	});
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch (parseError: unknown) {
-		const errorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-		if (!response.ok) {
-			throw new Error(`Failed to cleanup unused labels. Status: ${response.status} ${response.statusText}`);
-		}
-		throw new Error(`Unexpected response format when cleaning up labels: ${errorMessage}`);
-	}
-
-	if (!response.ok) {
-		let errorMessage = "Failed to cleanup unused labels";
-		if (typeof data === "object" && data !== null && "message" in data && typeof data.message === "string") {
-			errorMessage = data.message;
-		}
-		throw new Error(`${errorMessage}: ${response.statusText} (Status: ${response.status})`);
-	}
-
-	const parsed = CleanupLabelsResponseSchema.safeParse(data);
-	if (!parsed.success) {
-		throw new Error(`Invalid API response after cleaning up labels. Zod errors: ${parsed.error.message}`);
-	}
+	const data = await requestJson(
+		"/api/labels/cleanup",
+		{
+			method: "DELETE",
+		},
+		CleanupLabelsResponseSchema,
+		"Failed to cleanup unused labels",
+	);
 
 	return {
-		deletedCount: parsed.data.deletedCount,
-		deletedLabels: parsed.data.deletedLabels,
-		message: parsed.data.message,
+		deletedCount: data.deletedCount,
+		deletedLabels: data.deletedLabels,
+		message: data.message,
 	};
 }

--- a/mcp/src/tools.test.ts
+++ b/mcp/src/tools.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./lib/apiClient.js", () => ({
+	getUnlabeledArticles: vi.fn(),
+	getLabels: vi.fn(),
+	assignLabelToArticle: vi.fn(),
+	getLabelById: vi.fn(),
+	assignLabelsToMultipleArticles: vi.fn(),
+	getUnreadBookmarks: vi.fn(),
+}));
+
+import * as apiClient from "./lib/apiClient.js";
+import {
+	handleAssignLabelsToMultipleArticlesTool,
+	handleAssignLabelTool,
+	handleGetLabelsTool,
+	handleGetUnreadBookmarksTool,
+} from "./tools.js";
+
+const mockedApiClient = vi.mocked(apiClient);
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+describe("tool handlers", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterAll(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("handleGetLabelsTool: ラベル一覧をJSONとして返却する", async () => {
+		const labels = [
+			{
+				id: 1,
+				name: "Tech",
+				description: null,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			},
+		];
+		mockedApiClient.getLabels.mockResolvedValueOnce(labels);
+
+		const result = await handleGetLabelsTool();
+
+		expect(mockedApiClient.getLabels).toHaveBeenCalled();
+		expect(result).toEqual({
+			content: [{ type: "text", text: JSON.stringify(labels, null, 2) }],
+			isError: false,
+		});
+	});
+
+	it("handleAssignLabelTool: 成功時は完了メッセージを返す", async () => {
+		mockedApiClient.assignLabelToArticle.mockResolvedValueOnce(undefined);
+
+		const result = await handleAssignLabelTool({ articleId: 42, labelName: "Tech", description: "desc" });
+
+		expect(mockedApiClient.assignLabelToArticle).toHaveBeenCalledWith(42, "Tech", "desc");
+		expect(result).toEqual({
+			content: [{ type: "text", text: 'Successfully assigned label "Tech" to article ID 42.' }],
+			isError: false,
+		});
+	});
+
+	it("handleAssignLabelTool: 失敗時はエラーメッセージを返す", async () => {
+		mockedApiClient.assignLabelToArticle.mockRejectedValueOnce(new Error("network failure"));
+
+		const result = await handleAssignLabelTool({ articleId: 1, labelName: "Tech", description: null });
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Failed to assign label: network failure" }],
+			isError: true,
+		});
+		expect(consoleErrorSpy).toHaveBeenCalled();
+	});
+
+	it("handleAssignLabelsToMultipleArticlesTool: 入力検証エラーを返す", async () => {
+		const result = await handleAssignLabelsToMultipleArticlesTool({
+			articleIds: [],
+			labelName: "Tech",
+			description: null,
+		});
+
+		expect(result).toEqual({
+			content: [{ type: "text", text: "Failed to batch assign labels: articleIds must be a non-empty array" }],
+			isError: true,
+		});
+	});
+
+	it("handleGetUnreadBookmarksTool: 未読ブックマークを文字列化する", async () => {
+		const bookmarks = [
+			{
+				id: 10,
+				url: "https://example.com/10",
+				title: "記事10",
+				labels: ["Tech"],
+				isRead: false,
+				isFavorite: false,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				readAt: null,
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			},
+		];
+		mockedApiClient.getUnreadBookmarks.mockResolvedValueOnce(bookmarks);
+
+		const result = await handleGetUnreadBookmarksTool();
+
+		expect(mockedApiClient.getUnreadBookmarks).toHaveBeenCalled();
+		expect(result).toEqual({
+			content: [{ type: "text", text: `未読のブックマークリスト:\n${JSON.stringify(bookmarks, null, 2)}` }],
+			isError: false,
+		});
+	});
+});

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -1,0 +1,192 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import * as apiClient from "./lib/apiClient.js";
+
+type ToolContent = {
+	type: "text";
+	text: string;
+};
+
+type ToolResult = {
+	content: ToolContent[];
+	isError: boolean;
+};
+
+function wrapSuccess(text: string): ToolResult {
+	return {
+		content: [{ type: "text", text }],
+		isError: false,
+	};
+}
+
+function wrapError(text: string): ToolResult {
+	return {
+		content: [{ type: "text", text }],
+		isError: true,
+	};
+}
+
+export async function handleGetUnlabeledArticlesTool(): Promise<ToolResult> {
+	try {
+		const articles = await apiClient.getUnlabeledArticles();
+		return wrapSuccess(JSON.stringify(articles, null, 2));
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error("Error in getUnlabeledArticles tool:", errorMessage);
+		return wrapError(`Error fetching unlabeled articles: ${errorMessage}`);
+	}
+}
+
+export async function handleGetLabelsTool(): Promise<ToolResult> {
+	try {
+		const labels = await apiClient.getLabels();
+		return wrapSuccess(JSON.stringify(labels, null, 2));
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error("Error in getLabels tool:", errorMessage);
+		return wrapError(`Error fetching labels: ${errorMessage}`);
+	}
+}
+
+export async function handleAssignLabelTool({
+	articleId,
+	labelName,
+	description,
+}: {
+	articleId: number;
+	labelName: string;
+	description?: string | null;
+}): Promise<ToolResult> {
+	try {
+		await apiClient.assignLabelToArticle(articleId, labelName, description ?? undefined);
+		return wrapSuccess(`Successfully assigned label "${labelName}" to article ID ${articleId}.`);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error(
+			`Error in assignLabel tool (articleId: ${articleId}, labelName: ${labelName}, description: ${description}):`,
+			errorMessage,
+		);
+		return wrapError(`Failed to assign label: ${errorMessage}`);
+	}
+}
+
+export async function handleGetLabelByIdTool({ labelId }: { labelId: number }): Promise<ToolResult> {
+	try {
+		const label = await apiClient.getLabelById(labelId);
+		return wrapSuccess(`Label details: ${JSON.stringify(label, null, 2)}`);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error(`Error in getLabelById tool (labelId: ${labelId}):`, errorMessage);
+		return wrapError(`Failed to get label: ${errorMessage}`);
+	}
+}
+
+export async function handleAssignLabelsToMultipleArticlesTool({
+	articleIds,
+	labelName,
+	description,
+}: {
+	articleIds: number[];
+	labelName: string;
+	description?: string | null;
+}): Promise<ToolResult> {
+	try {
+		if (!articleIds || !Array.isArray(articleIds) || articleIds.length === 0) {
+			throw new Error("articleIds must be a non-empty array");
+		}
+		if (!labelName || typeof labelName !== "string") {
+			throw new Error("labelName must be a non-empty string");
+		}
+
+		console.error("Calling assignLabelsToMultipleArticles with:", {
+			articleIds,
+			labelName,
+			description,
+		});
+
+		const result = await apiClient.assignLabelsToMultipleArticles(articleIds, labelName, description ?? undefined);
+		return wrapSuccess(
+			`Successfully batch assigned label "${labelName}" to articles. Result: ${JSON.stringify(result, null, 2)}`,
+		);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error(
+			`Error in assignLabelsToMultipleArticles tool (articleIds: ${JSON.stringify(articleIds)}, labelName: ${labelName}, description: ${description}):`,
+			errorMessage,
+		);
+		console.error("Full error details:", error);
+		return wrapError(`Failed to batch assign labels: ${errorMessage}`);
+	}
+}
+
+export async function handleGetUnreadBookmarksTool(): Promise<ToolResult> {
+	try {
+		const bookmarks = await apiClient.getUnreadBookmarks();
+		return wrapSuccess(`未読のブックマークリスト:\n${JSON.stringify(bookmarks, null, 2)}`);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error("Error in getUnreadBookmarks tool:", errorMessage);
+		return wrapError(`未読ブックマークの取得に失敗しました: ${errorMessage}`);
+	}
+}
+
+export function registerTools(server: McpServer) {
+	// --- ツール定義 ---
+
+	// 1. ラベル未設定の記事を取得するツール
+	server.tool(
+		"getUnlabeledArticles",
+		{}, // 引数なし
+		async () => handleGetUnlabeledArticlesTool(),
+	);
+
+	// 2. 既存ラベル一覧を取得するツール
+	server.tool(
+		"getLabels",
+		{}, // 引数なし
+		async () => handleGetLabelsTool(),
+	);
+
+	// 3. 記事にラベルを付与するツール
+	server.tool(
+		"assignLabel",
+		// Zodで引数スキーマを定義
+		{
+			articleId: z.number().int().positive(),
+			labelName: z.string().min(1),
+			description: z.string().optional().nullable(),
+		},
+		async ({ articleId, labelName, description }) => handleAssignLabelTool({ articleId, labelName, description }),
+	);
+
+	// 4. ラベルIDからラベルを取得するツール
+	server.tool(
+		"getLabelById",
+		{
+			labelId: z.number().int().positive(),
+		},
+		async ({ labelId }) => handleGetLabelByIdTool({ labelId }),
+	);
+
+	// 5. 複数記事にラベルを一括付与するツール
+	server.tool(
+		"assignLabelsToMultipleArticles",
+		// Zodで引数スキーマを定義
+		{
+			articleIds: z.array(z.number().int().positive()),
+			labelName: z.string().min(1),
+			description: z.string().optional().nullable(),
+		},
+		async ({ articleIds, labelName, description }) =>
+			handleAssignLabelsToMultipleArticlesTool({ articleIds, labelName, description }),
+	);
+
+	// 6. 未読ブックマークを取得するツール
+	server.tool(
+		"getUnreadBookmarks",
+		{}, // 引数なし
+		async () => handleGetUnreadBookmarksTool(),
+	);
+
+	// --- ツール定義ここまで ---
+}


### PR DESCRIPTION
## 目的
- MCPサーバーのツール定義を分離し、テスト容易性を高める
- MCPパッケージ向けCIにユニットテストを追加する
- MCP設計ドキュメントに最新構成を反映する

## 変更範囲
- mcp/src/index.ts・tools.tsの構成調整とコメント日本語化
- MCP向けVitestテストの追加とツール層テストの移設
- APIクライアント共通ヘルパー導入とテスト更新
- docs/設計/mcp-サーバー設計.mdの更新
- CIワークフローにpnpm test追加

## 動作確認
- pnpm run format
- pnpm run lint
- pnpm run test
- pnpm run typecheck

close #1016