### PR TITLE
**対応内容**

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -61,5 +61,6 @@ Claude Desktopで利用する場合は設定ファイル（macOS例: `~/Library/
 - Lint: `pnpm run lint`
 - フォーマット: `pnpm run format`
 - 型チェック: `pnpm run typecheck`
+- テスト: `pnpm run test`（watchモードは無効化されているため、毎回ワンショット実行されます）
 
 必要に応じて `pnpm run build -- --watch` を使用するとTypeScriptの再ビルドを監視できます。

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
+		watch: false,
 		globals: true,
 		environment: "node",
 		include: ["src/**/*.{test,spec}.{js,ts}"],


### PR DESCRIPTION
close #1102
- `mcp/vitest.config.ts:5` に `watch: false` を追加し、Vitestが常にワンショット実行になるよう明示しました。CLIで誤って`vitest`単体を叩いた場合もwatchモードに入らず、Issue要件どおり「run」挙動に統一されています。
- `mcp/README.md:60-66` にテストコマンドを追記し、watchモード無効化の旨を明記しました。これで開発タスク一覧からもテスト手順の変更点を確認できます。
- `mcp/package.json` の `test` スクリプトは既に `vitest run` だったため追加のwatch解除は不要であることを確認済みです。

**テスト**
- `cd mcp && pnpm run test`（Vitest 8件成功）

追加の対応は特に不要ですが、必要に応じて他パッケージのテスト運用も同様に整理してください。