### PR TITLE
#1203 api/tests/test-utils.tsの削除 (vibe-kanban)

### DIFF
--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,5 +1,10 @@
 import { vi } from "vitest";
-import { mockFetch } from "./test-utils";
+
+const defaultFetchResponse = {
+	text: () => Promise.resolve("<title>Example Title</title>"),
+};
+
+const mockFetch = vi.fn().mockResolvedValue(defaultFetchResponse);
 
 vi.stubGlobal("fetch", mockFetch);
 

--- a/api/tests/test-utils.ts
+++ b/api/tests/test-utils.ts
@@ -1,9 +1,0 @@
-import { vi } from "vitest";
-
-const defaultFetchResponse = {
-	text: () => Promise.resolve("<title>Example Title</title>"),
-};
-
-export const mockFetch = vi.fn().mockResolvedValue(defaultFetchResponse);
-
-// TODO: 不要になったので削除予定


### PR DESCRIPTION
closes #1203

## 背景
- api/tests/test-utils.ts が現行テスト構成で不要になっている
- 重複/未使用のユーティリティを残さないようにしたい

## やりたいこと
- 当該テストユーティリティを削除する
- 参照しているテストがないか確認し、必要に応じて置き換えまたは整理する

## 期待する結果
- 不要なテストユーティリティが除去され、テストコードのメンテナンス性が向上する