### PR TITLE
#1200 api/tests/unit/repositoriesのテストを実装隣に移動 (vibe-kanban)

### DIFF
--- a/api/src/repositories/articleLabel.test.ts
+++ b/api/src/repositories/articleLabel.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ArticleLabel } from "../../../src/db/schema";
-import { ArticleLabelRepository } from "../../../src/repositories/articleLabel";
+import type { ArticleLabel } from "../db/schema";
+import { ArticleLabelRepository } from "./articleLabel";
 
 const mockDb = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/batch-label.test.ts
+++ b/api/src/repositories/batch-label.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ArticleLabelRepository } from "../../../src/repositories/articleLabel";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+import { ArticleLabelRepository } from "./articleLabel";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 // Mock Drizzle modules
 vi.mock("drizzle-orm/d1", () => ({

--- a/api/src/repositories/bookmark.test.ts
+++ b/api/src/repositories/bookmark.test.ts
@@ -7,9 +7,9 @@ import {
 	favorites,
 	type Label,
 	labels,
-} from "../../../src/db/schema";
-import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+} from "../db/schema";
+import type { BookmarkWithLabel } from "../interfaces/repository/bookmark";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 const mockDbClient = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/duplicate-fix-verification.test.ts
+++ b/api/src/repositories/duplicate-fix-verification.test.ts
@@ -5,7 +5,7 @@
  * ソート順序を維持することを確認します。
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 const mockDbClient = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/duplicate-sorting.test.ts
+++ b/api/src/repositories/duplicate-sorting.test.ts
@@ -7,7 +7,7 @@
  * - この違いによりソート順序が異なって見える可能性がある
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 const mockDbClient = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/label.test.ts
+++ b/api/src/repositories/label.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Label } from "../../../src/db/schema";
-import { LabelRepository } from "../../../src/repositories/label";
+import type { Label } from "../db/schema";
+import { LabelRepository } from "./label";
 
 const mockDb = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/markAsUnread.test.ts
+++ b/api/src/repositories/markAsUnread.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { bookmarks } from "../../../src/db/schema";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+import { bookmarks } from "../db/schema";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 const mockDbClient = {
 	select: vi.fn().mockReturnThis(),

--- a/api/src/repositories/sorting-fix-verification.test.ts
+++ b/api/src/repositories/sorting-fix-verification.test.ts
@@ -5,8 +5,8 @@
 
 import { desc, inArray } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { articleLabels, bookmarks } from "../../../src/db/schema";
-import { DrizzleBookmarkRepository } from "../../../src/repositories/bookmark";
+import { articleLabels, bookmarks } from "../db/schema";
+import { DrizzleBookmarkRepository } from "./bookmark";
 
 // モックDBクライアント
 const mockDbClient = {


### PR DESCRIPTION
closes #1200

## 背景
- api/tests/unit/repositories 配下のテストが実装ディレクトリから離れており、変更時の追従が煩雑

## やりたいこと
- リポジトリ実装ファイルの隣にテストを配置し、管理をシンプルにする
- 移動後もテストが正常に動作するようパスや設定を調整する

## 期待する結果
- リポジトリ実装とテストが同じ階層にまとまり、メンテナンス性が向上する
- テスト実行が現行と同等または簡素な手順で行える