### PR TITLE
#1201 api/tests/unit/routesのテストを実装隣に移動 (vibe-kanban)

### DIFF
--- a/api/src/index.test.ts
+++ b/api/src/index.test.ts
@@ -1,8 +1,8 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import type { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Env } from "../../../src/index";
-import { createApp } from "../../../src/index";
+import type { Env } from "./index";
+import { createApp } from "./index";
 
 // モックの設定
 

--- a/api/src/routes/batch-label.test.ts
+++ b/api/src/routes/batch-label.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Label } from "../../../src/db/schema";
-import type { IBookmarkService } from "../../../src/interfaces/service/bookmark";
-import type { ILabelService } from "../../../src/interfaces/service/label";
-import { createBookmarksRouter } from "../../../src/routes/bookmarks";
+import type { Label } from "../db/schema";
+import type { IBookmarkService } from "../interfaces/service/bookmark";
+import type { ILabelService } from "../interfaces/service/label";
+import { createBookmarksRouter } from "./bookmarks";
 
 // テスト用の型定義
 interface BatchLabelSuccessResponse {
@@ -18,11 +18,11 @@ interface ErrorResponse {
 	message: string;
 }
 
-vi.mock("../../../src/services/bookmark", () => ({
+vi.mock("../services/bookmark", () => ({
 	BookmarkService: vi.fn(),
 }));
 
-vi.mock("../../../src/services/label", () => ({
+vi.mock("../services/label", () => ({
 	LabelService: vi.fn(),
 }));
 

--- a/api/src/routes/bookmarks-unread.test.ts
+++ b/api/src/routes/bookmarks-unread.test.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NotFoundError } from "../../../src/exceptions";
-import type { Env } from "../../../src/index";
-import type { IBookmarkService } from "../../../src/interfaces/service/bookmark";
-import type { ILabelService } from "../../../src/interfaces/service/label";
-import { createBookmarksRouter } from "../../../src/routes/bookmarks";
+import { NotFoundError } from "../exceptions";
+import type { Env } from "../index";
+import type { IBookmarkService } from "../interfaces/service/bookmark";
+import type { ILabelService } from "../interfaces/service/label";
+import { createBookmarksRouter } from "./bookmarks";
 
 describe("Bookmark Unread Endpoint", () => {
 	let app: Hono<{ Bindings: Env }>;

--- a/api/src/routes/bookmarks.test.ts
+++ b/api/src/routes/bookmarks.test.ts
@@ -1,12 +1,12 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Bookmark, Label } from "../../../src/db/schema";
-import { NotFoundError } from "../../../src/exceptions";
-import type { Env } from "../../../src/index";
-import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";
-import type { IBookmarkService } from "../../../src/interfaces/service/bookmark";
-import type { ILabelService } from "../../../src/interfaces/service/label";
-import { createBookmarksRouter } from "../../../src/routes/bookmarks";
+import type { Bookmark, Label } from "../db/schema";
+import { NotFoundError } from "../exceptions";
+import type { Env } from "../index";
+import type { BookmarkWithLabel } from "../interfaces/repository/bookmark";
+import type { IBookmarkService } from "../interfaces/service/bookmark";
+import type { ILabelService } from "../interfaces/service/label";
+import { createBookmarksRouter } from "./bookmarks";
 
 // interface PaginationResponse {
 // 	success: boolean;

--- a/api/src/routes/labels.test.ts
+++ b/api/src/routes/labels.test.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Label } from "../../../src/db/schema";
+import type { Label } from "../db/schema";
 import {
 	createErrorResponse,
 	createErrorResponseBody,
 	toContentfulStatusCode,
-} from "../../../src/exceptions";
-import type { Env } from "../../../src/index";
-import type { ILabelService } from "../../../src/interfaces/service/label";
+} from "../exceptions";
+import type { Env } from "../index";
+import type { ILabelService } from "../interfaces/service/label";
 
 // 日付文字列とDateオブジェクトを比較するためのヘルパー関数
 function compareObjectsIgnoringDateFormat(

--- a/api/src/routes/unrated-bookmarks.test.ts
+++ b/api/src/routes/unrated-bookmarks.test.ts
@@ -3,10 +3,10 @@
  */
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BookmarkWithLabel } from "../../../src/interfaces/repository/bookmark";
-import type { IBookmarkService } from "../../../src/interfaces/service/bookmark";
-import type { ILabelService } from "../../../src/interfaces/service/label";
-import { createBookmarksRouter } from "../../../src/routes/bookmarks";
+import type { BookmarkWithLabel } from "../interfaces/repository/bookmark";
+import type { IBookmarkService } from "../interfaces/service/bookmark";
+import type { ILabelService } from "../interfaces/service/label";
+import { createBookmarksRouter } from "./bookmarks";
 
 // モックサービス
 const mockBookmarkService: IBookmarkService = {


### PR DESCRIPTION
closes #1201

## 背景
- api/tests/unit/routes 配下のテストが実装から離れており、修正時の参照コストが高い

## やりたいこと
- ルート実装ファイルの隣にテストを配置し、変更追従を容易にする
- 移動に伴うインポート/パスの調整を行い、テストが問題なく動作することを確認する

## 期待する結果
- ルート実装とテストが同じ階層にまとまり、開発体験とメンテナンス性が向上する