### PR TITLE
#1202 api/tests/unit/servicesのテストを実装隣に移動 (vibe-kanban)

### DIFF
--- a/api/src/services/batch-label.test.ts
+++ b/api/src/services/batch-label.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { BookmarkWithLabel, Label } from "../../../src/db/schema";
-import type { IArticleLabelRepository } from "../../../src/interfaces/repository/articleLabel";
-import type { IBookmarkRepository } from "../../../src/interfaces/repository/bookmark";
-import type { ILabelRepository } from "../../../src/interfaces/repository/label";
-import { LabelService } from "../../../src/services/label";
+import type { BookmarkWithLabel, Label } from "../db/schema";
+import type { IArticleLabelRepository } from "../interfaces/repository/articleLabel";
+import type { IBookmarkRepository } from "../interfaces/repository/bookmark";
+import type { ILabelRepository } from "../interfaces/repository/label";
+import { LabelService } from "./label";
 
 describe("LabelService - 一括ラベル付け機能", () => {
 	let labelService: LabelService;

--- a/api/src/services/bookmark.test.ts
+++ b/api/src/services/bookmark.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Bookmark, Label } from "../../../src/db/schema";
+import type { Bookmark, Label } from "../db/schema";
 import type {
 	BookmarkWithLabel,
 	IBookmarkRepository,
-} from "../../../src/interfaces/repository/bookmark";
-import type { IBookmarkService } from "../../../src/interfaces/service/bookmark";
-import { DefaultBookmarkService } from "../../../src/services/bookmark";
+} from "../interfaces/repository/bookmark";
+import type { IBookmarkService } from "../interfaces/service/bookmark";
+import { DefaultBookmarkService } from "./bookmark";
 
 describe("DefaultBookmarkService", () => {
 	let service: IBookmarkService;

--- a/api/src/services/label.test.ts
+++ b/api/src/services/label.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Label } from "../../../src/db/schema";
-import type { IArticleLabelRepository } from "../../../src/interfaces/repository/articleLabel";
+import type { Label } from "../db/schema";
+import type { IArticleLabelRepository } from "../interfaces/repository/articleLabel";
 import type {
 	BookmarkWithLabel,
 	IBookmarkRepository,
-} from "../../../src/interfaces/repository/bookmark";
-import type { ILabelRepository } from "../../../src/interfaces/repository/label";
-import { LabelService } from "../../../src/services/label";
+} from "../interfaces/repository/bookmark";
+import type { ILabelRepository } from "../interfaces/repository/label";
+import { LabelService } from "./label";
 
 const mockFindAllWithArticleCount = vi.fn();
 const mockFindLabelByName = vi.fn();

--- a/api/src/services/markAsUnread.test.ts
+++ b/api/src/services/markAsUnread.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { IBookmarkRepository } from "../../../src/interfaces/repository/bookmark";
-import { DefaultBookmarkService } from "../../../src/services/bookmark";
+import type { IBookmarkRepository } from "../interfaces/repository/bookmark";
+import { DefaultBookmarkService } from "./bookmark";
 
 describe("markBookmarkAsUnread", () => {
 	let service: DefaultBookmarkService;

--- a/api/src/services/unratedBookmarks.test.ts
+++ b/api/src/services/unratedBookmarks.test.ts
@@ -5,8 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
 	BookmarkWithLabel,
 	IBookmarkRepository,
-} from "../../../src/interfaces/repository/bookmark";
-import { DefaultBookmarkService } from "../../../src/services/bookmark";
+} from "../interfaces/repository/bookmark";
+import { DefaultBookmarkService } from "./bookmark";
 
 // モックデータ
 const mockUnratedBookmarks: BookmarkWithLabel[] = [


### PR DESCRIPTION
closes #1202

## 背景
- api/tests/unit/services 配下のテストが実装から離れており、修正時の同期が煩雑

## やりたいこと
- サービス実装ファイルの隣にテストを配置し、変更の見通しを良くする
- 移動に伴うパス調整を行い、テストが問題なく動作することを確認する

## 期待する結果
- サービス実装とテストが同じ階層にまとまり、メンテナンス性と開発効率が向上する