### PR TITLE
#1204 api/tests/setup.tsをapi配下へ移動 (vibe-kanban)

### DIFF
--- a/api/src/tests/setup.ts
+++ b/api/src/tests/setup.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { mockFetch } from "./test-utils";
+import { mockFetch } from "../../tests/test-utils";
 
 vi.stubGlobal("fetch", mockFetch);
 

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		environment: "node",
 		// CI/ローカルともに単発実行を強制
 		watch: false,
-		setupFiles: ["./tests/setup.ts"],
+		setupFiles: ["./src/tests/setup.ts"],
 		// in-source testingを有効化
 		includeSource: ["src/**/*.ts"],
 		// typecheck mode for better TypeScript support


### PR DESCRIPTION
closes #1204

## 背景
- api/tests/setup.ts がテストルート直下にあり、実装に近い場所へ移したい
- テストセットアップを実装構成に合わせて整理する目的

## やりたいこと
- setup.ts を api/ 配下（実装に隣接する適切な場所）へ移動する
- パスやインポート、設定を調整し、テスト実行が問題なく行えるようにする

## 期待する結果
- テストセットアップが実装構造に沿って配置され、見通しとメンテナンス性が向上する