### PR TITLE
#1207 api/wrangler.jsoncのtrigger削除 (vibe-kanban)

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -34,9 +34,6 @@
 		"enabled": true,
 		"head_sampling_rate": 1
 	},
-	"triggers": {
-		"crons": ["0 0 * * *"]
-	},
 	"env": {
 		"development": {
 			"vars": {


### PR DESCRIPTION
closes #1207

## 背景
- wrangler.jsonc の trigger は現状不要になっていると考えられる

## やりたいこと
- api/wrangler.jsonc から trigger 設定を削除する
- 削除による影響範囲を確認し、必要なら代替手順を記載する

## 期待する結果
- wrangler設定がシンプルになり、不要な設定が排除される
- デプロイ/実行フローが現状の運用に整合する