### PR TITLE
#1206 api/biome.jsonのlinterルールをrecommendedのみに変更 (vibe-kanban)

### DIFF
--- a/api/biome.json
+++ b/api/biome.json
@@ -26,27 +26,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
-			"a11y": {
-				"noSvgWithoutTitle": "off",
-				"useSemanticElements": "off"
-			},
-			"suspicious": {
-				"noArrayIndexKey": "off",
-				"noConfusingVoidType": "off"
-			},
-			"style": {
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error"
-			}
+			"recommended": true
 		}
 	},
 	"javascript": {


### PR DESCRIPTION
closes #1206

## 背景
- Biomeのlinter設定が複数ルールを有効化しており、基本セットに絞りたい

## やりたいこと
- api/biome.json の linter.rules を recommended のみに変更する
- 既存ルールの上書き・個別指定を見直し、必要ならコメントで意図を明記する

## 期待する結果
- linter設定がシンプルになり、意図しないルール衝突がなくなる
- Biomeのrecommendedに沿った最小構成で運用できる