### PR TITLE
#1208 api/wrangler.jsoncの不要なコメントアウト削除 (vibe-kanban)

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -7,18 +7,6 @@
 	"vars": {
 		"ENVIRONMENT": "production"
 	},
-	// "kv_namespaces": [
-	//   {
-	//     "binding": "MY_KV_NAMESPACE",
-	//     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	//   }
-	// ],
-	// "r2_buckets": [
-	//   {
-	//     "binding": "MY_BUCKET",
-	//     "bucket_name": "my-bucket"
-	//   }
-	// ],
 	"d1_databases": [
 		{
 			"binding": "DB",
@@ -27,9 +15,6 @@
 			"migrations_dir": "drizzle"
 		}
 	],
-	// "ai": {
-	//   "binding": "AI"
-	// },
 	"observability": {
 		"enabled": true,
 		"head_sampling_rate": 1
@@ -39,7 +24,6 @@
 			"vars": {
 				"ENVIRONMENT": "development"
 			},
-			// 開発環境用のローカルD1データベース設定
 			"d1_databases": [
 				{
 					"binding": "DB",


### PR DESCRIPTION
closes #1208

## 背景
- wrangler.jsonc に不要なコメントアウトが残っており、設定の可読性を下げている

## やりたいこと
- api/wrangler.jsonc から不要なコメントアウトを削除する
- 必要な情報は最小限のコメントまたはドキュメントに整理する

## 期待する結果
- wrangler設定ファイルが簡潔になり、設定意図が明瞭になる