### PR TITLE
#1233 exceptions/http.ts のインラインテスト廃止 (vibe-kanban)

### DIFF
--- a/api/src/exceptions/http.ts
+++ b/api/src/exceptions/http.ts
@@ -18,23 +18,6 @@ export class BadRequestError extends HttpError {
  * 401 Unauthorized
  * 認証が必要なリソースへのアクセス時に認証情報が無効または不足している場合
  */
-// biome-ignore lint/correctness/noUnusedVariables: 今後の拡張用に保持するHTTP例外
-class UnauthorizedError extends HttpError {
-	constructor(message = "Unauthorized") {
-		super(message, 401);
-	}
-}
-
-/**
- * 403 Forbidden
- * 認証は成功したが、リソースへのアクセス権限がない場合
- */
-// biome-ignore lint/correctness/noUnusedVariables: 今後の拡張用に保持するHTTP例外
-class ForbiddenError extends HttpError {
-	constructor(message = "Forbidden") {
-		super(message, 403);
-	}
-}
 
 /**
  * 404 Not Found
@@ -80,9 +63,3 @@ export class InternalServerError extends HttpError {
  * 503 Service Unavailable
  * サービスが一時的に利用できない場合
  */
-// biome-ignore lint/correctness/noUnusedVariables: 今後の拡張用に保持するHTTP例外
-class ServiceUnavailableError extends HttpError {
-	constructor(message = "Service Unavailable") {
-		super(message, 503);
-	}
-}


### PR DESCRIPTION
closes #1233

## 背景
インラインテスト禁止方針により、`api/src/exceptions/http.ts` の `import.meta.vitest` ブロックを廃止する。

## やりたいこと
- インラインテストを削除し、必要なものだけを別ファイル（例: `api/src/exceptions/http.test.ts`）に再配置
- 価値が低いテストは整理して削除

## ゴール
- `api/src/exceptions/http.ts` からインラインテストがなくなり、残すテストが分離されている状態