### PR TITLE
#1241 config/timezone.ts のインラインテスト廃止 (vibe-kanban)

### DIFF
--- a/api/src/config/timezone.test.ts
+++ b/api/src/config/timezone.test.ts
@@ -1,17 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { createTimezoneConfig, TIMEZONE_CONFIG } from "./timezone";
+import { createTimezoneConfig } from "./timezone";
 
 describe("timezone config", () => {
 	test("フォーマット設定が正しく定義されている", () => {
 		const config = createTimezoneConfig();
 		expect(config.format.dateOnly).toBe("YYYY-MM-DD");
 		expect(config.format.datetime).toBe("YYYY-MM-DD HH:mm:ss");
-	});
-
-	test("後方互換性のためのTIMEZONE_CONFIGが利用可能", () => {
-		expect(TIMEZONE_CONFIG.default).toBe("Asia/Tokyo");
-		expect(TIMEZONE_CONFIG.format.dateOnly).toBe("YYYY-MM-DD");
-		expect(TIMEZONE_CONFIG.format.datetime).toBe("YYYY-MM-DD HH:mm:ss");
 	});
 });

--- a/api/src/config/timezone.ts
+++ b/api/src/config/timezone.ts
@@ -16,6 +16,6 @@ export function createTimezoneConfig() {
 }
 
 /**
- * デフォルトのタイムゾーン設定（後方互換性のため）
+ * デフォルトのタイムゾーン設定
  */
 export const TIMEZONE_CONFIG = createTimezoneConfig();


### PR DESCRIPTION
closes #1241

## 背景
インラインテスト禁止方針により、`api/src/config/timezone.ts` の `import.meta.vitest` ブロックを廃止する。

## やりたいこと
- インラインテストを削除し、必要なものは別ファイル（例: `api/src/config/timezone.test.ts`）に移行
- テスト価値を精査して不要なら削除

## ゴール
- `api/src/config/timezone.ts` からインラインテストがなくなり、残すテストは分離されている状態