### PR TITLE
🛠️ fix: BFF上流URLを本番に設定

### DIFF
--- a/frontend/wrangler.jsonc
+++ b/frontend/wrangler.jsonc
@@ -16,6 +16,9 @@
 	"observability": {
 		"enabled": true
 	},
+	"vars": {
+		"BFF_API_BASE_URL": "https://effective-yomimono-api.ryosuke-horie37.workers.dev"
+	},
 	"kv_namespaces": [
 		{
 			"binding": "NEXT_INC_CACHE_KV",


### PR DESCRIPTION
## 目的\nBFF経由の上流API URLが未設定の環境で解決不能となるため、本番の上流URLを固定する。\n\n## 変更範囲\n- frontend/wrangler.jsonc: BFF_API_BASE_URL を vars に追加\n\n## 動作確認手順\n- 未実施（設定変更のみ）\n\n## スクリーンショット\n- なし\n\ncloses #1313\n