### PR TITLE
fix: BFFのデフォルトAPI URLを更新

### DIFF
--- a/frontend/src/lib/bff/config.ts
+++ b/frontend/src/lib/bff/config.ts
@@ -7,10 +7,15 @@ export interface CacheControlPolicy {
 	mustRevalidate?: boolean;
 }
 
-const DEFAULT_API_BASE_URL = "https://api-yomimono.workers.dev";
+const DEFAULT_API_BASE_URL =
+	"https://effective-yomimono-api.ryosuke-horie37.workers.dev";
 
 export function getUpstreamApiBaseUrl(): string {
-	return process.env.BFF_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+	return (
+		process.env.BFF_API_BASE_URL ??
+		process.env.NEXT_PUBLIC_API_BASE_URL ??
+		DEFAULT_API_BASE_URL
+	);
 }
 
 export function getUpstreamApiKey(): string | undefined {


### PR DESCRIPTION
## 目的
- BFFのデフォルトAPI URLが古く、ブックマーク取得時に上流API解析エラーになる問題の解消

## 変更範囲
- BFFのAPIベースURLのデフォルトを最新URLに更新
- BFF_API_BASE_URL未設定時にNEXT_PUBLIC_API_BASE_URLへフォールバック

## 動作確認
- pnpm -C frontend run lint
- pnpm -C frontend run format

## スクリーンショット
- 変更なし

closes #1315
