### PR TITLE
refactor: deploy スキルを runbook-deploy にリネーム

### DIFF
--- a/.claude/skills/runbook-deploy/SKILL.md
+++ b/.claude/skills/runbook-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: deploy
-description: yomimono プロジェクトの本番デプロイを実行する。API → Frontend の順にデプロイし、Extension の手動提出手順を案内する。/deploy コマンドでトリガーする。
+name: runbook-deploy
+description: yomimono プロジェクトの本番デプロイを実行する。API → Frontend の順にデプロイし、Extension の手動提出手順を案内する。/runbook-deploy コマンドでトリガーする。
 disable-model-invocation: true
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,5 +143,5 @@ export function distance(a: Point, b: Point): number {
 
 以下のスキルは `/skill-name` コマンドでトリガーできます。
 
-- `/deploy`: yomimono プロジェクトの本番デプロイを実行する。D1 バックアップ → マイグレーション → API デプロイ → Frontend デプロイ の順に処理し、Extension の手動提出手順を案内する。
+- `/runbook-deploy`: yomimono プロジェクトの本番デプロイを実行する。D1 バックアップ → マイグレーション → API デプロイ → Frontend デプロイ の順に処理し、Extension の手動提出手順を案内する。
 - `/rss-add <URL>`: RSSフィード定義を追加する。指定URLのRSSフィードを検証し、api/src/config/feeds.ts に新しいフィード定義を追記する。


### PR DESCRIPTION
## Summary
- `.claude/skills/deploy/` を `.claude/skills/runbook-deploy/` にリネーム
- SKILL.md の `name` と CLAUDE.md のスラッシュコマンド説明を更新
- 命名規約 (runbook 系スキルは `runbook-` プレフィックス) に合わせる

Closes YOMIMONO-30

<!-- copilot review in Japanese -->