### PR TITLE
chore: Dependabot更新PRを2系統に集約

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,148 +1,69 @@
 version: 2
 updates:
-  # ルート（モノレポ共通）の依存関係を管理
-  # pnpm workspace 全体を対象とし、複数ディレクトリで共通するパッケージを一括管理する
-  # サブディレクトリ固有パッケージの重複 PR を防止するため、ルート管理対象を共通ツールのみに絞る
+  # npm/pnpm 依存を monorepo 全体でまとめて確認する。
+  # 本番ビルド、デプロイ、実行互換性をまとめて確認する更新と、開発補助ツールの更新を分ける。
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/api"
+      - "/frontend"
+      - "/extension"
     schedule:
       interval: "monthly"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 2
     commit-message:
-      prefix: "chore(root)"
-      prefix-development: "chore(root-dev)"
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
       include: "scope"
     reviewers:
       - "ryosuke-horie"
     assignees:
       - "ryosuke-horie"
-    allow:
-      - dependency-name: "lefthook"
-      - dependency-name: "@biomejs/biome"
-      - dependency-name: "knip"
-      - dependency-name: "typescript"
-      - dependency-name: "wrangler"
-      - dependency-name: "@cloudflare/workers-types"
-      - dependency-name: "@types/node"
     groups:
-      shared-tools:
+      runtime-dependencies:
+        applies-to: "version-updates"
         patterns:
-          # モノレポ共通ツール（ルート package.json）
-          - "lefthook"
-          # 全ディレクトリ共通：静的解析・フォーマット・型チェック
-          - "@biomejs/biome"
-          - "knip"
-          - "typescript"
-          # api/frontend 共通：Cloudflare 関連デプロイツール
-          - "wrangler"
           - "@cloudflare/workers-types"
-          # api/frontend/extension 共通：Node.js 型定義
-          - "@types/node"
-
-  # apiディレクトリ固有の依存関係を管理
-  # 共通パッケージはルート設定の shared-tools グループで一括管理するため、ここでは除外する
-  # ignore リストはルート設定の allow リストと対応する。共通ツール追加時は両方を更新���ること
-  - package-ecosystem: "npm"
-    directory: "/api"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore(api)"
-      prefix-development: "chore(api-dev)"
-      include: "scope"
-    reviewers:
-      - "ryosuke-horie"
-    assignees:
-      - "ryosuke-horie"
-    ignore:
-      - dependency-name: "@biomejs/biome"
-      - dependency-name: "knip"
-      - dependency-name: "typescript"
-      - dependency-name: "wrangler"
-      - dependency-name: "@cloudflare/workers-types"
-      - dependency-name: "@types/node"
-    groups:
-      api-deps:
-        patterns:
-          # コアとなる実行時依存パッケージ
+          - "@opennextjs/cloudflare"
+          - "wrangler"
+          - "workerd"
+          - "next"
+          - "react"
+          - "react-dom"
+          - "@tanstack/react-query"
+          - "react-icons"
+          - "server-only"
           - "hono"
           - "drizzle-orm"
           - "drizzle-kit"
           - "dotenv"
           - "fast-xml-parser"
-          # データベース関連
           - "better-sqlite3"
           - "@types/better-sqlite3"
-          # ビルドツール
-          - "tsx"
-      api-dev-deps:
-        patterns:
-          # テスト関連
-          - "vitest"
-          - "@vitest/*"
-          - "happy-dom"
-          # 開発ツール
-          - "openapi3-ts"
-          - "yaml"
-          - "only-allow"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
-
-  # frontendディレクトリ固有の依存関係を管理
-  # 共通パッケージはルート設定の shared-tools グループで一括管理するため、ここでは除外する
-  # ignore リストはルート設定の allow リストと対応する。共通ツール追加時は両方を更新すること
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore(frontend)"
-      prefix-development: "chore(frontend-dev)"
-      include: "scope"
-    reviewers:
-      - "ryosuke-horie"
-    assignees:
-      - "ryosuke-horie"
-    ignore:
-      - dependency-name: "@biomejs/biome"
-      - dependency-name: "knip"
-      - dependency-name: "typescript"
-      - dependency-name: "wrangler"
-      - dependency-name: "@cloudflare/workers-types"
-      - dependency-name: "@types/node"
-    groups:
-      frontend-deps:
-        patterns:
-          # Reactとそのエコシステム
-          - "next"
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-          - "@tanstack/react-query"
-          - "react-icons"
-          - "server-only"
-          # Cloudflareデプロイメント（frontend固有）
-          - "@opennextjs/cloudflare"
-          # スタイリング関連
           - "tailwindcss"
           - "@tailwindcss/postcss"
           - "postcss"
           - "postcss-load-config"
-          # コード生成ツール
-          - "orval"
-      frontend-dev-deps:
+      development-tooling:
+        applies-to: "version-updates"
         patterns:
-          # テスト関連
+          - "@biomejs/biome"
+          - "knip"
+          - "typescript"
+          - "@types/node"
+          - "@types/react"
+          - "@types/react-dom"
           - "vitest"
           - "@vitest/*"
-          - "@testing-library/*"
+          - "happy-dom"
           - "jsdom"
-          # ビルドツール
+          - "@testing-library/*"
           - "vite"
           - "@vitejs/plugin-react"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
+          - "tsx"
+          - "orval"
+          - "openapi3-ts"
+          - "yaml"
+          - "only-allow"
+          - "lefthook"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,9 +123,10 @@ export function distance(a: Point, b: Point): number {
 
 ## 依存関係管理
 - **Dependabot**: `.github/dependabot.yml`で設定
-  - 各ディレクトリごと（ルート, api, frontend, extension）に個別に依存関係を管理
-  - 依存パッケージはグループ化されており、関連パッケージは一括で更新される
-  - テスト関連パッケージ（vitest, @vitest/*）は同時に更新する必要があるためグループ化
+  - ルート, api, frontend, extension の npm/pnpm 依存関係を1つの設定で管理する
+  - 本番ビルド、デプロイ、実行互換性に関わる依存は `runtime-dependencies` として一括更新する
+  - テスト、静的解析、型チェック、コード生成などの開発補助ツールは `development-tooling` として一括更新する
+  - version updates は月1回実行し、通常の依存更新 PR を2系統に集約する
 
 ## 言語設定
 - 日本語での解答生成を優先する


### PR DESCRIPTION
## 目的
Dependabot の通常依存更新 PR を確認しやすくするため、monorepo 全体の npm/pnpm 更新を runtime 系と開発補助ツール系の2系統に集約します。

## 変更範囲
- `.github/dependabot.yml` を単一の npm 設定に統合
- `/`, `/api`, `/frontend`, `/extension` を `directories` で一括管理
- `runtime-dependencies` と `development-tooling` の2グループへ分類
- 実行頻度を月1回に設定
- `CLAUDE.md` の Dependabot 運用方針を新しい設定に合わせて更新

## 動作確認
- YAML parse OK
- 直参照依存が全件 `runtime-dependencies` / `development-tooling` のどちらかに分類されることを確認
- `git diff --check`
- AIレビュー: ロジック、セキュリティ、コメント方針、規約準拠の再レビューで指摘なし
